### PR TITLE
fix(ui): broken tools nav

### DIFF
--- a/components/organisms/ToolList/nav.tsx
+++ b/components/organisms/ToolList/nav.tsx
@@ -32,7 +32,7 @@ const Nav: React.FC<NavProps> = ({ toolList, selectedTool = "dashboard", selecte
           key={index} className={`tool-list-item ${selectedTool === tool.name.toLowerCase() ? "" : ""}`}>
           <Link href={`/${filterName}/${tool.name.toLowerCase()}${selectedFilter ? `/filter/${selectedFilter}` : ""}`} >
             {/* Button component was here and needed to be removed to resolve issue #187. Button component had styling that will eventually need to be replaced. */}
-            <div className={`flex pb-1t px-2 md:px-4 hover:!bg-slate-100 after:block after:relative after:inset-x-0 after:-bottom-0.5 after:h-0.5 after:rounded-lg ${selectedTool === tool.name.toLowerCase() ? "after:bg-orange-500" : "focus:after:bg-slate-400"} focus:bg-slate-100 focus:ring-slate-300 child:flex child:items-center`}>
+            <div className={`flex pb-1 px-2 md:px-4 hover:!bg-slate-100 after:block after:relative after:inset-x-0 after:-bottom-0.5 after:h-0.5 after:rounded-lg ${selectedTool === tool.name.toLowerCase() ? "after:bg-orange-500" : "focus:after:bg-slate-400"} focus:bg-slate-100 focus:ring-slate-300 child:flex child:items-center`}>
               <span className={"text-base whitespace-nowrap " + (selectedTool === tool.name.toLowerCase() ? "text-slate-900" : "text-slate-500")}>
                 {tool.name}
               </span>


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

The tools nav broken when addressing #187. This adds display flex and some padding to at the very least make it presentable. It also moves the position of the yellow selection to be absolute. That still needs to be fix.


## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
fixes #193

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
<img width="666" alt="Screen Shot 2022-08-13 at 11 43 32 AM" src="https://user-images.githubusercontent.com/5713670/184506978-ed27be86-86e7-4c75-aaba-8892ea6a6cec.png">
missing yellow bar below

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

The UI needs to re-introduce the yellow line, but that should be separate.

<img width="194" alt="Screen Shot 2022-08-13 at 11 56 29 AM" src="https://user-images.githubusercontent.com/5713670/184507252-8c86fc4d-8f58-47e4-8b8c-9478cf28f1d9.png">

https://github.com/open-sauced/insights/issues/195

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<img src="https://media2.giphy.com/media/10gMDcaONSDLfq/giphy.gif"/>