### PR TITLE
fix: max width removed from card

### DIFF
--- a/components/atoms/Card/card.tsx
+++ b/components/atoms/Card/card.tsx
@@ -8,7 +8,7 @@ interface CardProps {
 
 const Card: React.FC<CardProps> = ({ className, children, heading }) => {
   return (
-    <article className={`${className ? className : ""} block ${heading ? "" : "p-6"} max-w-2xl bg-white rounded-lg drop-shadow-md`}>
+    <article className={`${className ? className : ""} block ${heading ? "" : "p-6"} bg-white rounded-lg drop-shadow-md`}>
       {
         heading ?
           <>
@@ -19,9 +19,9 @@ const Card: React.FC<CardProps> = ({ className, children, heading }) => {
               {children}
             </div>
           </>
-          
+
           :
-          
+
           children
       }
     </article>


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
While working on something else, I noticed that the width for the scattered chart was not 100%. This was introduced because of a fix to the design system. I am reverting to ensure the scatter chart is displayed as designed. 

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
fixes #249

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

<img width="1840" alt="Screen Shot 2022-08-21 at 5 37 20 PM" src="https://user-images.githubusercontent.com/5713670/185818489-a58b101c-5e4a-46a1-9be4-b171ee8351aa.png">

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<img src="https://media2.giphy.com/media/11s7Ke7jcNxCHS/giphy.gif"/>