### PR TITLE
fix: removed duplicate repoList name in contributors card 

### DIFF
--- a/components/molecules/CardRepoList/card-repo-list.tsx
+++ b/components/molecules/CardRepoList/card-repo-list.tsx
@@ -15,7 +15,6 @@ interface CardRepoListProps {
 const CardRepoList = ({ repoList }: CardRepoListProps): JSX.Element => {
   
   const sanitizedRepoList = [...new Map(repoList.map(item => [item["repoName"], item])).values()];
-  console.log(sanitizedRepoList);
   return (
     <div className="flex gap-2 items-center font-medium flex-wrap text-xs text-light-slate-11">
       {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR removes duplicate repo names from the contributors card

### Details
Had three method of approach in solving this issue, but used one..`Map`. 

**Here is how it works currently:**

First the array is remapped in a way that it can be used as an input for a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)

>arr.map(item => [item[key], item]);

which means each item of the array will be transformed in another array with 2 elements; the selected key as first element and the entire initial item as second element. [Example can be found here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Relation_with_Array_objects).


Secondly, we pass this modified array to the Map constructor and here is where the magic is happening. Map will eliminate the duplicate keys values, keeping only last inserted value of the same key. Note: Map keeps the order of insertion. 

Third we use the map values to retrieve the original items, but this time without duplicates.

>new Map(mappedArr).values()


And last one is to add those values into a fresh new array so that it can look as the initial structure and return that:

>[...new Map(mappedArr).values()]

Same solution can be achieved using a `for` loop or array `filter`. But i choose Map as it reduces the lines of code and also looks cleaner and readable. 

As for perfomance, not really sure if Map serves better 🙏
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
Fixes #463
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

