### PR TITLE
fix: pr overview empty space

### DIFF
--- a/components/atoms/PullRequestOverviewChart/pull-request-overview-chart.tsx
+++ b/components/atoms/PullRequestOverviewChart/pull-request-overview-chart.tsx
@@ -21,9 +21,12 @@ const PullRequestOverviewChartBar: React.FC<PullRequestOverviewChartBarProps & R
         ? "bg-purple-600"
         : type === "closed"
           ? "bg-light-red-9"
-          : "bg-light-slate-9"
+          : type === "draft"
+            ? "bg-light-slate-9"
+            : ""
     }
-        transition-all duration-500 ease-in-out rounded-full`}
+    ${percent === 0 && "hidden"}
+        transition-all shrink-0 duration-500 ease-in-out rounded-full`}
       style={{ width: `${percent}%` }}
     ></div>
   );
@@ -55,16 +58,40 @@ const PullRequestOverviewChart: React.FC<PullRequestOverviewChartProps> = ({
   return (
     <div className="w-full h-1.5 flex gap-0.5 bg-light-slate-2 rounded-full overflow-hidden">
       {/* Open */}
-      {open && open > 0 && <PullRequestOverviewChartBar onMouseOver={()=> setOverviewDetails({type: "open", percent: open})} percent={getPercentage(open)} type="open" />}
+      {open && open > 0 && (
+        <PullRequestOverviewChartBar
+          onMouseOver={() => setOverviewDetails({ type: "open", percent: open })}
+          percent={getPercentage(open)}
+          type="open"
+        />
+      )}
 
       {/* Merged */}
-      {merged && merged > 0 && <PullRequestOverviewChartBar onMouseOver={()=> setOverviewDetails({type: "merged", percent: merged})} percent={getPercentage(merged)} type="merged" />}
+      {merged && merged > 0 && (
+        <PullRequestOverviewChartBar
+          onMouseOver={() => setOverviewDetails({ type: "merged", percent: merged })}
+          percent={getPercentage(merged)}
+          type="merged"
+        />
+      )}
 
       {/* Closed */}
-      {closed && closed > 0 && <PullRequestOverviewChartBar onMouseOver={()=> setOverviewDetails({type: "closed", percent: closed})} percent={getPercentage(closed)} type="closed" />}
+      {closed && closed > 0 && (
+        <PullRequestOverviewChartBar
+          onMouseOver={() => setOverviewDetails({ type: "closed", percent: closed })}
+          percent={getPercentage(closed)}
+          type="closed"
+        />
+      )}
 
       {/* Draft */}
-      {draft && draft > 0 && <PullRequestOverviewChartBar percent={getPercentage(draft)} type="draft" />}
+      {draft && draft > 0 && (
+        <PullRequestOverviewChartBar
+          onMouseOver={() => setOverviewDetails({ type: "draft", percent: draft })}
+          percent={getPercentage(draft)}
+          type="draft"
+        />
+      )}
     </div>
   );
 };

--- a/components/molecules/PullRequestOverview/pull-request-overview.tsx
+++ b/components/molecules/PullRequestOverview/pull-request-overview.tsx
@@ -23,8 +23,9 @@ const PullRequestOverview: React.FC<PullRequestOverviewProps> = ({
   churnDirection = "down",
   prActiveCount
 }) => {
-  const totalPullRequests =
-    (!!open ? open : 0) + (!!merged ? merged : 0) + (!!closed ? closed : 0) + (!!draft ? draft : 0);
+  const totalPullRequests = Math.round(
+    (!!open ? open : 0) + (!!merged ? merged : 0) + (!!closed ? closed : 0) + (!!draft ? draft : 0)
+  );
   const prCount = prActiveCount || 0;
   const activePrPercentage = totalPullRequests > 0 ? Math.round((prCount / totalPullRequests) * 100) : 0;
   // used this state to manage actively hovered pull request overview chart


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR:

- Fixes the empty spaces on `PullRequestOverviewChart` component
- updates draft pr to include mouse hover features to show the percentage

### Solution
Added a `shrink-0` class to individual chart bar to enable dem span the width of the container and remove empty spaces
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents

Fixes #447 
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings
### Before 
<img width="1440" alt="Screenshot 2022-12-10 at 08 08 51" src="https://user-images.githubusercontent.com/62995161/206837126-355b01ba-f7f3-48a8-a4b6-fcf4e27b8a42.png">


### After
<img width="1440" alt="Screenshot 2022-12-10 at 08 07 20" src="https://user-images.githubusercontent.com/62995161/206836851-63862c6a-5b47-486b-8068-d85fe335d830.png">

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

