### PR TITLE
fix: `/user/[username]` route/page browser support issue

### DIFF
--- a/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
+++ b/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
@@ -64,7 +64,8 @@ const ContributorProfileTab = ({
 
   const router = useRouter();
 
-  pathnameRef.current = router.pathname.split("/").at(-1);
+  const pathnames = router.pathname.split("/");
+  pathnameRef.current = pathnames[pathnames.length - 1];
 
   const getCurrentPathName = useMemo(() => {
     return pathnameRef.current && pathnameRef.current !== "[username]"

--- a/e2e-tests/OpenUserProfile.spec.ts
+++ b/e2e-tests/OpenUserProfile.spec.ts
@@ -6,8 +6,8 @@ test("Open a User (with GitHub Account Connected) Profile", async ({ page }) => 
   await expect(page).toHaveURL(/\/user\/babblebey/, { timeout: 10000 });
   await expect(page).toHaveTitle(/babblebey | OpenSauced/);
   await expect(page.getByRole("heading", { name: "babblebey" })).toBeVisible();
-  await expect(page.getByAltText("Avatar")).toBeVisible();
-  await expect(page.getByAltText("user profile cover image")).toBeVisible();
+  await expect(page.getByRole("img", { name: "Avatar" })).toBeVisible();
+  await expect(page.getByRole("img", { name: "user profile cover image" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Get Card" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Share" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Contributions" })).toBeVisible();
@@ -19,8 +19,8 @@ test("Open a User (without Github Account Connected) Profile", async ({ page }) 
   await expect(page).toHaveURL("/user/githubuser", { timeout: 10000 });
   await expect(page).toHaveTitle(/githubuser | OpenSauced/);
   await expect(page.getByRole("heading", { name: "githubuser" })).toBeVisible();
-  await expect(page.getByAltText("Avatar")).toBeHidden();
-  await expect(page.getByAltText("user profile cover image")).toBeHidden();
+  await expect(page.getByRole("img", { name: "Avatar" })).toBeHidden();
+  await expect(page.getByRole("img", { name: "user profile cover image" })).toBeHidden();
   await expect(page.getByRole("link", { name: "Get Card" })).toBeHidden();
   await expect(page.getByRole("button", { name: "Share" })).toBeHidden();
   await expect(page.getByRole("button", { name: "Contributions" })).toBeHidden();

--- a/e2e-tests/OpenUserProfile.spec.ts
+++ b/e2e-tests/OpenUserProfile.spec.ts
@@ -10,7 +10,7 @@ test("Open a User (with GitHub Account Connected) Profile", async ({ page }) => 
   await expect(page.getByRole("img", { name: "user profile cover image" })).toBeVisible();
   await expect(page.getByRole("link", { name: "Get Card" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Share" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Contributions" })).toBeVisible();
+  await expect(page.getByRole("tab")).toBeVisible();
 });
 
 test("Open a User (without Github Account Connected) Profile", async ({ page }) => {
@@ -23,6 +23,6 @@ test("Open a User (without Github Account Connected) Profile", async ({ page }) 
   await expect(page.getByRole("img", { name: "user profile cover image" })).toBeHidden();
   await expect(page.getByRole("link", { name: "Get Card" })).toBeHidden();
   await expect(page.getByRole("button", { name: "Share" })).toBeHidden();
-  await expect(page.getByRole("button", { name: "Contributions" })).toBeHidden();
+  await expect(page.getByRole("tab")).toBeHidden();
   await expect(page.getByRole("heading", { name: "Contribution Insights" })).toBeVisible();
 });

--- a/e2e-tests/OpenUserProfile.spec.ts
+++ b/e2e-tests/OpenUserProfile.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test("Open a User (with GitHub Account Connected) Profile", async ({ page }) => {
+  await page.goto("/user/babblebey", { waitUntil: "domcontentloaded" });
+
+  await expect(page).toHaveURL(/\/user\/babblebey\/highlights/, { timeout: 10000 });
+  await expect(page).toHaveTitle(/babblebey | OpenSauced/);
+  await expect(page.getByRole("heading", { name: "babblebey" })).toBeVisible();
+  await expect(page.getByAltText("Avatar")).toBeVisible();
+  await expect(page.getByAltText("user profile cover image")).toBeVisible();
+  await expect(page.getByRole("link", { name: "Get Card" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Share" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Contributions" })).toBeVisible();
+});
+
+test("Open a User (without Github Account Connected) Profile", async ({ page }) => {
+  await page.goto("/user/githubuser", { waitUntil: "domcontentloaded" });
+
+  await expect(page).toHaveURL("/user/githubuser", { timeout: 10000 });
+  await expect(page).toHaveTitle(/githubuser | OpenSauced/);
+  await expect(page.getByRole("heading", { name: "githubuser" })).toBeVisible();
+  await expect(page.getByAltText("Avatar")).toBeHidden();
+  await expect(page.getByAltText("user profile cover image")).toBeHidden();
+  await expect(page.getByRole("link", { name: "Get Card" })).toBeHidden();
+  await expect(page.getByRole("button", { name: "Share" })).toBeHidden();
+  await expect(page.getByRole("button", { name: "Contributions" })).toBeHidden();
+  await expect(page.getByRole("heading", { name: "Contribution Insights" })).toBeVisible();
+});

--- a/e2e-tests/OpenUserProfile.spec.ts
+++ b/e2e-tests/OpenUserProfile.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test("Open a User (with GitHub Account Connected) Profile", async ({ page }) => {
   await page.goto("/user/babblebey", { waitUntil: "domcontentloaded" });
 
-  await expect(page).toHaveURL(/\/user\/babblebey\/highlights/, { timeout: 10000 });
+  await expect(page).toHaveURL(/\/user\/babblebey/, { timeout: 10000 });
   await expect(page).toHaveTitle(/babblebey | OpenSauced/);
   await expect(page.getByRole("heading", { name: "babblebey" })).toBeVisible();
   await expect(page.getByAltText("Avatar")).toBeVisible();


### PR DESCRIPTION
## Description

This Pull Request addresses the browser compatibility issue causing regression on the `/user/[username]` route on some mobile browsers, which arose from the usage of `at` array method in the component below...

https://github.com/open-sauced/insights/blob/c4c56098826f085e5c551e088ac4fc3ada969f34/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx#L67

### Changes Made

- Considering the intention was to select the last item on the array returned from `router.pathname.split('/')`, I replaced the usage of `at` array method with a computation of `[array].length - 1` then use the derived value as `index` to access needed item.

```js
const pathnames = router.pathname.split("/");
pathnameRef.current = pathnames[pathnames.length - 1];
```

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

Fixes #1493 

## Mobile & Desktop Screenshots/Recordings

**Before**

![image](https://github.com/open-sauced/insights/assets/25631971/7d342d7f-6307-47d2-afce-30ebf4a65dc0)

**After**

[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2023.08.19-18_14_05.webm](https://github.com/open-sauced/insights/assets/25631971/01ba73ae-1cd9-439e-9817-2ce2f6e45e57)

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

NA

## [optional] What gif best describes this PR or how it makes you feel?

![giphy (1)](https://github.com/open-sauced/insights/assets/25631971/5e515b44-beac-4d77-b7bf-8e40ffc8c195)


<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
