### PR TITLE
fix: query param reset in repo filters & URL encoding

### DIFF
--- a/components/organisms/FollowersHighlightWrapper/following-highlight-wrapper.tsx
+++ b/components/organisms/FollowersHighlightWrapper/following-highlight-wrapper.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from "react";
 import Link from "next/link";
-import { useRouter } from "next/router";
 
 import formatDistanceToNowStrict from "date-fns/formatDistanceToNowStrict";
 
 import { useFetchFollowingHighlights } from "lib/hooks/useFetchFollowingHighlights";
+import { setQueryParams } from "lib/utils/query-params";
 
 import Avatar from "components/atoms/Avatar/avatar";
 import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
@@ -18,15 +18,15 @@ export interface HighlightWrapperProps {
   selectedFilter: string;
 }
 const FollowingHighlightWrapper = ({ emojis, selectedFilter }: HighlightWrapperProps) => {
-  const router = useRouter();
   const { data, isLoading, isError, mutate, meta, setPage } = useFetchFollowingHighlights(selectedFilter);
 
   useEffect(() => {
     if (selectedFilter) {
-      router.push(`/feed?repo=${selectedFilter}`);
+      setQueryParams({ repo: selectedFilter });
       setPage(1);
     }
-  }, [selectedFilter]);
+  }, [selectedFilter, setPage]);
+
   return (
     <div>
       <div className="flex flex-col gap-8 mt-10">

--- a/lib/utils/query-params.ts
+++ b/lib/utils/query-params.ts
@@ -1,0 +1,30 @@
+import { ParsedUrlQuery } from "querystring";
+import Router from "next/router";
+
+/**
+ * Sets query parameters in the URL using Next.js Router.
+ * @param {Record<string, string>} params - An object containing key-value pairs of query parameters to set. Pass in `{}`(an empty object) to skip.
+ * @param {Array<string>} [paramsToRemove=[]] - An optional array of query parameter keys to remove from the URL. To skip use `[]`(an empty array).
+ * @param {string | undefined} [pathname] - An optional variable for providing the pathname to go to.
+ */
+function setQueryParams(params: Record<string, string>, paramsToRemove: Array<string> = [], pathname?: string) {
+  const presentQueryParams = deleteKeys(Router.query, paramsToRemove);
+
+  // Merge final query and set URL
+  Router.push({
+    pathname: pathname || Router.pathname,
+    query: {
+      ...presentQueryParams,
+      ...params,
+    },
+  });
+}
+
+function deleteKeys<T extends ParsedUrlQuery, K extends keyof T>(obj: T, keys: K[]): T {
+  for (const key of keys) {
+    delete obj[key];
+  }
+  return obj;
+}
+
+export { setQueryParams };

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -14,6 +14,7 @@ import useFetchAllEmojis from "lib/hooks/useFetchAllEmojis";
 import { useFetchFollowersHighlightRepos } from "lib/hooks/useFetchFollowingHighlightRepos";
 import { useFetchUser } from "lib/hooks/useFetchUser";
 import { useFetchFeaturedHighlights } from "lib/hooks/useFetchFeaturedHighlights";
+import { setQueryParams } from "lib/utils/query-params";
 
 import { WithPageLayout } from "interfaces/with-page-layout";
 import ProfileLayout from "layouts/profile";
@@ -160,12 +161,7 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
     setSelectedRepo("");
 
     // Resetting URL search param for repo
-    const params = new URLSearchParams(window.location.search);
-    params.delete("repo");
-    router.push({
-      pathname: router.pathname,
-      search: params.toString(),
-    });
+    setQueryParams({}, ["repo"]);
 
     // Changing the active tab
     setActiveTab(value as activeTabType);
@@ -363,10 +359,11 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
             <HighlightsFilterCard
               setSelected={(repo) => {
                 if (!openSingleHighlight) {
-                  const queryParams = new URLSearchParams(window.location.search);
-                  router.push(
-                    `/feed${repo ? `?repo=${repo}` : queryParams.toString() ? `?${queryParams.toString()}` : ""}`
-                  );
+                  if (repo) {
+                    setQueryParams({ repo });
+                  } else {
+                    setQueryParams({}, ["repo"]);
+                  }
                   setPage(1);
                   setSelectedRepo(repo);
                 }


### PR DESCRIPTION
## Description

- Query params are now being reset on resetting repository filters
- URL is now encoded

Fixes #1589 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #1589 

## Mobile & Desktop Screenshots/Recordings

| Before | After |
| --- | --- |
| ![image](https://github.com/open-sauced/app/assets/27003616/fd677508-fa06-4476-9eb5-b4bd9eb1b786) | <video src="https://github.com/open-sauced/app/assets/27003616/603148ec-e231-41f4-a1bb-ca017a882e18" /> |

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed


