### PR TITLE
fix: "53y" showing up as first PR age in Contributor hover Card for dashboard

### DIFF
--- a/components/molecules/ContributorHoverCard/contributor-hover-card.tsx
+++ b/components/molecules/ContributorHoverCard/contributor-hover-card.tsx
@@ -34,7 +34,10 @@ const ContributorHoverCard = ({
   const { filterName } = router.query;
   const topic = filterName as string;
 
-  const calculatedDateFromToday = dateOfFirstPr ? calcDistanceFromToday(new Date(parseInt(dateOfFirstPr))) : "-";
+  const calculatedDateFromToday = dateOfFirstPr
+    ? calcDistanceFromToday(new Date(parseInt(dateOfFirstPr).toString()))
+    : "-";
+
   return (
     <div className="w-[364px] bg-white gap-4 p-3 rounded-lg shadow-superlative flex flex-col">
       <div className="flex items-center justify-between">


### PR DESCRIPTION
## Description

Miscalculation of first PR age was happening because `new Date()` was receiving a numeric value. Resulting in `1970` year being passed to the next function and hence the `53 years age`.
I have made sure to convert the number to a string type using `toString()` method.

Fixes #1606 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #1606 

## Mobile & Desktop Screenshots/Recordings

| Before | After |
| ---- | ---- |
| ![image](https://github.com/open-sauced/app/assets/27003616/39b5aa03-8b44-4feb-b5a2-f87b371aeda0) | ![image](https://github.com/open-sauced/app/assets/27003616/c5be58ba-922f-45d3-b063-d14ec13df49d) |

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

