### PR TITLE
fix: repo filter query not filtering on page refresh (1610)

### DIFF
--- a/components/molecules/HighlightsFeedCard/highlights-filter-card.tsx
+++ b/components/molecules/HighlightsFeedCard/highlights-filter-card.tsx
@@ -1,21 +1,15 @@
-import { useEffect, useState } from "react";
 import Title from "components/atoms/Typography/title";
 import Icon from "components/atoms/Icon/icon";
 
 interface HighlightsFilterCardProps {
   repos: { repoName: string; repoIcon: string; full_name: string }[];
-  setSelected?: (selected: string) => void;
+  setSelected: (selected: string) => void;
+  selectedFilter: string;
 }
-const HighlightsFilterCard = ({ repos, setSelected }: HighlightsFilterCardProps): JSX.Element => {
-  const [selected, setSelectedRepo] = useState("");
-
+const HighlightsFilterCard = ({ repos, setSelected, selectedFilter }: HighlightsFilterCardProps): JSX.Element => {
   const handleClick = (name: string) => {
-    setSelectedRepo((prev) => (prev === name ? "" : name));
+    setSelected(selectedFilter === name ? "" : name);
   };
-
-  useEffect(() => {
-    setSelected?.(selected);
-  }, [selected]);
 
   return (
     <div className="py-4 px-6 rounded-lg bg-light-slate-1  border w-full h-max">
@@ -29,7 +23,7 @@ const HighlightsFilterCard = ({ repos, setSelected }: HighlightsFilterCardProps)
             onClick={() => handleClick(full_name)}
             key={(repoName + repoIcon) as string}
             className={`${
-              selected === full_name ? "border-orange-600 bg-orange-200" : ""
+              selectedFilter === full_name ? "border-orange-600 bg-orange-200" : ""
             } flex hover:border-orange-600 hover:bg-orange-200 cursor-pointer gap-1 w-max  p-1 pr-2 border-[1px] border-light-slate-6 rounded-lg text-light-slate-12`}
           >
             <Icon IconImage={repoIcon} className="rounded-[4px] overflow-hidden" />

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -63,7 +63,7 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
 
   const router = useRouter();
   const [openSingleHighlight, setOpenSingleHighlight] = useState(false);
-  const [selectedRepo, setSelectedRepo] = useState("");
+  const selectedRepo = (router.query.repo as string) || "";
   const [activeTab, setActiveTab] = useState<activeTabType>("home");
   const [repoList, setRepoList] = useState<highlightReposType[]>(repoTofilterList(repos as highlightReposType[]));
   const [hydrated, setHydrated] = useState(false);
@@ -157,9 +157,6 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
   }, []);
 
   function onTabChange(value: string) {
-    // This is to handle resetting the filter state when the tab is switched
-    setSelectedRepo("");
-
     // Resetting URL search param for repo
     setQueryParams({}, ["repo"]);
 
@@ -366,10 +363,10 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
                     setQueryParams({}, ["repo"]);
                   }
                   setPage(1);
-                  setSelectedRepo(repo);
                 }
               }}
               repos={repoList}
+              selectedFilter={selectedRepo}
             />
           )}
 

--- a/stories/molecules/highlights-filter-card.stories.tsx
+++ b/stories/molecules/highlights-filter-card.stories.tsx
@@ -1,25 +1,41 @@
+import { useState } from "react";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
-import { ComponentStory } from "@storybook/react";
 import HighlightsFilterCard from "components/molecules/HighlightsFeedCard/highlights-filter-card";
+import type { Meta, StoryObj } from "@storybook/react";
 
-const StoryConfig = {
+const meta: Meta<typeof HighlightsFilterCard> = {
   title: "Design System/Molecules/HighlightsFilterCard",
+  component: HighlightsFilterCard,
 };
-export default StoryConfig;
+export default meta;
 
-const HighlightsFilterCardTemplate: ComponentStory<typeof HighlightsFilterCard> = () => (
-  <TooltipProvider>
-    {/* eslint-disable-next-line camelcase */}
-    <HighlightsFilterCard
-      repos={[
-        {
-          repoIcon: "https://www.github.com/open-sauced.png?size=300",
-          repoName: "app",
-          full_name: "open-sauced/app",
-        },
-      ]}
-    />
-  </TooltipProvider>
-);
+type Story = StoryObj<typeof HighlightsFilterCard>;
 
-export const Default = HighlightsFilterCardTemplate.bind({});
+const HighlightsFilterCardWithHooks = () => {
+  const [selectedFilter, setSelectedFilter] = useState("open-sauced/app");
+
+  function setSelected() {
+    setSelectedFilter((prev) => (prev ? "" : "open-sauced/app"));
+  }
+
+  return (
+    <TooltipProvider>
+      {/* eslint-disable-next-line camelcase */}
+      <HighlightsFilterCard
+        repos={[
+          {
+            repoIcon: "https://www.github.com/open-sauced.png?size=300",
+            repoName: "app",
+            full_name: "open-sauced/app",
+          },
+        ]}
+        selectedFilter={selectedFilter}
+        setSelected={setSelected}
+      />
+    </TooltipProvider>
+  );
+};
+
+export const Defautl: Story = {
+  render: () => <HighlightsFilterCardWithHooks />,
+};


### PR DESCRIPTION
## Description

Highlights - Repo filter query params not filtering on page refresh. The query params was not affecting the filters on page. Now, on page reload, it will select the repo present in the query param.

Fixes #1610 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #1610 

## Mobile & Desktop Screenshots/Recordings

| Before | After |
| ---- | ---- |
| <video src="https://github.com/open-sauced/app/assets/27003616/ddf13341-97d4-488d-8777-8b3b3cc9dfbc" /> | <video src="https://github.com/open-sauced/app/assets/27003616/b179d8b0-d323-45ab-a44a-a6452826bd81" /> |

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

