### PR TITLE
fix: hidden link on profile highlights (1618)

### DIFF
--- a/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
+++ b/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
@@ -163,11 +163,13 @@ const ContributorProfileTab = ({
                 <div>
                   {highlights.map(({ id, title, highlight, url, shipped_at, created_at, type, tagged_repos }) => (
                     <div className="flex flex-col gap-2 mb-6 lg:flex-row lg:gap-7" key={id}>
-                      <Link href={`/feed/${id}`}>
-                        <p className="text-sm text-light-slate-10 w-28 max-w-28">
-                          {formatDistanceToNowStrict(new Date(created_at), { addSuffix: true })}
-                        </p>
-                      </Link>
+                      <div>
+                        <Link href={`/feed/${id}`}>
+                          <p className="text-sm text-light-slate-10 w-28 max-w-28">
+                            {formatDistanceToNowStrict(new Date(created_at), { addSuffix: true })}
+                          </p>
+                        </Link>
+                      </div>
                       <ContributorHighlightCard
                         emojis={emojis}
                         id={id}


### PR DESCRIPTION
## Description

A `<p>` tag which was a flex column, was getting extended along with the link wrapper on it. This caused a hidden link on profile page. I have wrapped the `Link` itself in a `<div>` which causes the flex column properties to apply over it and the children `Link` and `<p>` tag are not extended. The hidden link is now removed.

Fixes #1618 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #1618 

## Mobile & Desktop Screenshots/Recordings

[hidden-link.webm](https://github.com/open-sauced/app/assets/27003616/b6aa214a-f499-4e6f-babb-252934261466)

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

