### PR TITLE
fix: handle `401` error on collaboration feature

### DIFF
--- a/lib/hooks/useUserCollaborations.ts
+++ b/lib/hooks/useUserCollaborations.ts
@@ -37,7 +37,7 @@ const useUserCollaborations = () => {
       const response = await req?.json();
       if (response.statusCode === 401) {
         toast({
-          description: "You require an upgraded access to use collaboration!",
+          description: "You require upgraded access to use collaborations!",
           title: "Not allowed",
           variant: "danger",
         });

--- a/lib/hooks/useUserCollaborations.ts
+++ b/lib/hooks/useUserCollaborations.ts
@@ -42,7 +42,7 @@ const useUserCollaborations = () => {
           variant: "danger",
         });
       } else {
-        toast({ description: response.message[0], title: "Error", variant: "danger" });
+        toast({ description: response.message, title: "Error", variant: "danger" });
       }
 
       console.log(response.message);

--- a/lib/hooks/useUserCollaborations.ts
+++ b/lib/hooks/useUserCollaborations.ts
@@ -35,7 +35,15 @@ const useUserCollaborations = () => {
       toast({ description: "Collaboration request Sent!", title: "Success", variant: "success" });
     } else {
       const response = await req?.json();
-      toast({ description: response.message[0], title: "Error", variant: "danger" });
+      if (response.statusCode === 401) {
+        toast({
+          description: "You require an upgraded access to use collaboration!",
+          title: "Not allowed",
+          variant: "danger",
+        });
+      } else {
+        toast({ description: response.message[0], title: "Error", variant: "danger" });
+      }
 
       console.log(response.message);
     }


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

This Pull Request handles the `401` error that may occus on User collaboration request feature, due to restriction of the feature to only users with upgraded access to open-sauced. It adds a descriptive message to notify a user of the need of an upgraded access to use the feature.

### Changes Made

- Add a check for `statusCode` to error response, then append a new toast that carries required message
- ...and left other error to the default handling in the else block.

```js
// lib\hooks\useUserCollaborations.ts

if (req && req.ok) {
  const response = await req.json();
  toast({ description: "Collaboration request Sent!", title: "Success", variant: "success" });
} else {
  const response = await req?.json();

  // Changes From Here <--- 🍕🍕🍕🍕
  if (response.statusCode === 401) {
    toast({
      description: "You require an upgraded access to use collaboration!",
      title: "Not allowed",
      variant: "danger",
    });
  } else {
    toast({ description: response.message, title: "Error", variant: "danger" });
  }
  //🍕🍕🍕🍕
}
```

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

Fixes #1632 

## Mobile & Desktop Screenshots/Recordings
[screencast-localhost_3000-2023.09.10-18_03_22.webm](https://github.com/open-sauced/app/assets/25631971/93ae8511-bbff-4c14-8733-836fa0ee8c59)

<!-- Visual changes require screenshots -->


## Added tests ?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

NA

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
