### PR TITLE
fix: reset input state of delete list dialog box after closing the dialog and deleting the list

### DIFF
--- a/pages/hub/lists/index.tsx
+++ b/pages/hub/lists/index.tsx
@@ -38,6 +38,7 @@ const ListsHub: WithPageLayout = () => {
 
   const handleOnClose = () => {
     setIsDeleteOpen(false);
+    setText("");
   };
 
   const handleOnConfirm = async () => {
@@ -62,6 +63,7 @@ const ListsHub: WithPageLayout = () => {
       toast({ description: "An error occurred while deleting the list", variant: "danger" });
     } finally {
       setDeleteLoading(false);
+      setText("");
     }
   };
 


### PR DESCRIPTION
## Description

This PR resets input state of delete list dialog box after closing the dialog and deleting the list.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
Fixes #1848

## Mobile & Desktop Screenshots/Recordings

**Before the change:**

https://github.com/open-sauced/app/assets/27571141/6c757d2e-b7fb-442d-ac6f-2609d99f080d


**After the change:**

https://github.com/open-sauced/app/assets/27571141/7459e0b2-5462-41c3-8b71-6153c020a4cc



## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
