### PR TITLE
feat: improve small screen view for feed page

### DIFF
--- a/components/molecules/HighlightInput/highlight-input-form.tsx
+++ b/components/molecules/HighlightInput/highlight-input-form.tsx
@@ -940,7 +940,7 @@ const HighlightInputForm = ({ refreshCallback }: HighlightInputFormProps): JSX.E
         </div>
       )}
 
-      <Fab className="md:hidden">
+      <Fab className="md:hidden z-10">
         <div
           onClick={() => setIsFormOpenMobile(true)}
           className="p-3 mb-10 -mr-4 text-white rounded-full shadow-lg bg-light-orange-10"

--- a/components/molecules/HighlightsFeedCard/highlights-filter-card.tsx
+++ b/components/molecules/HighlightsFeedCard/highlights-filter-card.tsx
@@ -17,7 +17,7 @@ const HighlightsFilterCard = ({ repos, setSelected, selectedFilter }: Highlights
         Repositories
       </Title>
       <p className="mb-2 text-sm font-normal text-light-slate-11">Click to filter the highlights</p>
-      <div className="flex flex-col gap-2 pt-4 border-t">
+      <div className="flex flex-wrap gap-2 pt-4 border-t">
         {repos.map(({ repoName, repoIcon, full_name }) => (
           <div
             onClick={() => handleClick(full_name)}

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -200,33 +200,37 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
         className="container flex flex-col justify-center w-full gap-12 px-2 pt-12 mt-5 md:mt-0 md:items-start md:px-16 md:flex-row"
         ref={topRef}
       >
-        <div className={`sticky ${user ? "top-16" : "top-8"} xl:flex hidden flex-none w-1/5`}>
-          <div className="flex flex-col w-full gap-6 mt-12">
-            {user && (
-              <div className="w-full">
-                <UserCard
-                  loading={loggedInUserLoading}
-                  username={loggedInUser?.login as string}
-                  meta={userMetaArray as MetaObj[]}
-                  name={loggedInUser?.name as string}
-                />
-              </div>
-            )}
-            <TopContributorsPanel
-              loggedInUserLogin={loggedInUser?.login ?? ""}
-              loggedInUserId={loggedInUser?.id ?? undefined}
-              refreshLoggedInUser={refreshLoggedInUser}
-            />
-            <AnnouncementCard
-              title="#100DaysOfOSS 🚀 "
-              description={
-                "Join us for 100 days of supporting, sharing knowledge, and exploring the open source ecosystem together."
-              }
-              bannerSrc={
-                "https://user-images.githubusercontent.com/5713670/254358937-8e9aa76d-4ed3-4616-a58a-2283796b10e1.png"
-              }
-              url={"https://dev.to/opensauced/100daysofoss-growing-skills-and-real-world-experience-3o5k"}
-            />
+        <div className={`xl:sticky ${user ? "top-16" : "top-8"} flex flex-none xl:w-1/5`}>
+          <div className="flex flex-col w-full gap-6 mt-12 items-center">
+            <div className="gap-6 flex md:flex-col xs:flex-col sm:flex-row items-center w-full flex-wrap sm:flex-nowrap">
+              {user && (
+                <div className="w-full">
+                  <UserCard
+                    loading={loggedInUserLoading}
+                    username={loggedInUser?.login as string}
+                    meta={userMetaArray as MetaObj[]}
+                    name={loggedInUser?.name as string}
+                  />
+                </div>
+              )}
+              <TopContributorsPanel
+                loggedInUserLogin={loggedInUser?.login ?? ""}
+                loggedInUserId={loggedInUser?.id ?? undefined}
+                refreshLoggedInUser={refreshLoggedInUser}
+              />
+            </div>
+            <div className="hidden md:block">
+              <AnnouncementCard
+                title="#100DaysOfOSS 🚀 "
+                description={
+                  "Join us for 100 days of supporting, sharing knowledge, and exploring the open source ecosystem together."
+                }
+                bannerSrc={
+                  "https://user-images.githubusercontent.com/5713670/254358937-8e9aa76d-4ed3-4616-a58a-2283796b10e1.png"
+                }
+                url={"https://dev.to/opensauced/100daysofoss-growing-skills-and-real-world-experience-3o5k"}
+              />
+            </div>
           </div>
         </div>
         {singleHighlight && (

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -202,7 +202,7 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
       >
         <div className={`xl:sticky ${user ? "top-16" : "top-8"} flex flex-none xl:w-1/5`}>
           <div className="flex flex-col w-full gap-6 mt-12 items-center">
-            <div className="gap-6 flex md:flex-col xs:flex-col sm:flex-row items-center w-full flex-wrap sm:flex-nowrap">
+            <div className="gap-6 flex md:flex-col xs:flex-col sm:flex-row items-center w-full flex-wrap sm:flex-nowrap justify-center">
               {user && (
                 <div className="w-full">
                   <UserCard
@@ -298,89 +298,91 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
             </DialogContent>
           </Dialog>
         )}
-        <Tabs onValueChange={onTabChange} defaultValue="home" className="w-full 2xl:max-w-[40rem] xl:max-w-[33rem]">
-          <TabsList className={clsx("justify-start  w-full border-b", !user && "hidden")}>
-            <TabsTrigger
-              className="data-[state=active]:border-sauced-orange data-[state=active]:border-b-2 text-lg"
-              value="home"
-            >
-              Home
-            </TabsTrigger>
-            <TabsTrigger
-              className="data-[state=active]:border-sauced-orange  data-[state=active]:border-b-2 text-lg"
-              value="following"
-            >
-              Following
-            </TabsTrigger>
-          </TabsList>
+        <div className="flex flex-col w-full gap-12 md:items-start lg:flex-row">
+          <Tabs onValueChange={onTabChange} defaultValue="home" className="w-full 2xl:max-w-[40rem] xl:max-w-[33rem]">
+            <TabsList className={clsx("justify-start  w-full border-b", !user && "hidden")}>
+              <TabsTrigger
+                className="data-[state=active]:border-sauced-orange data-[state=active]:border-b-2 text-lg"
+                value="home"
+              >
+                Home
+              </TabsTrigger>
+              <TabsTrigger
+                className="data-[state=active]:border-sauced-orange  data-[state=active]:border-b-2 text-lg"
+                value="following"
+              >
+                Following
+              </TabsTrigger>
+            </TabsList>
 
-          {user && (
-            <div className="flex max-w-3xl px-1 pt-4 lg:gap-x-3">
-              <div className="hidden lg:inline-flex pt-[0.4rem]">
-                <Avatar
-                  alt="user profile avatar"
-                  isCircle
-                  size="sm"
-                  avatarURL={`https://www.github.com/${user?.user_metadata.user_name}.png?size=300`}
-                />
-              </div>
-
-              <HighlightInputForm refreshCallback={mutate} />
-            </div>
-          )}
-          <TabsContent value="home">
-            <HomeHighlightsWrapper emojis={emojis} mutate={mutate} highlights={data} loading={isLoading} />
-            {meta.pageCount > 1 && (
-              <div className="flex items-center justify-between max-w-3xl px-2 mt-10">
-                <div className="flex items-center w-max gap-x-4">
-                  <PaginationResults metaInfo={meta} total={meta.itemCount} entity={"highlights"} />
+            {user && (
+              <div className="flex max-w-3xl px-1 pt-4 lg:gap-x-3">
+                <div className="hidden lg:inline-flex pt-[0.4rem]">
+                  <Avatar
+                    alt="user profile avatar"
+                    isCircle
+                    size="sm"
+                    avatarURL={`https://www.github.com/${user?.user_metadata.user_name}.png?size=300`}
+                  />
                 </div>
-                <Pagination
-                  pages={[]}
-                  totalPage={meta.pageCount}
-                  page={meta.page}
-                  pageSize={meta.itemCount}
-                  goToPage
-                  hasNextPage={meta.hasNextPage}
-                  hasPreviousPage={meta.hasPreviousPage}
-                  onPageChange={function (page: number): void {
-                    setPage(page);
-                    if (topRef.current) {
-                      topRef.current.scrollIntoView({
-                        behavior: "smooth",
-                      });
-                    }
-                  }}
-                />
+
+                <HighlightInputForm refreshCallback={mutate} />
               </div>
             )}
-          </TabsContent>
-          <TabsContent value="following">
-            <FollowingHighlightWrapper selectedFilter={selectedRepo} emojis={emojis} />
-          </TabsContent>
-        </Tabs>
-        <div className="sticky flex-col flex-none hidden w-1/3 gap-6 mt-10 xl:w-1/4 lg:flex top-20">
-          {repoList && repoList.length > 0 && (
-            <HighlightsFilterCard
-              setSelected={(repo) => {
-                if (!openSingleHighlight) {
-                  if (repo) {
-                    setQueryParams({ repo });
-                  } else {
-                    setQueryParams({}, ["repo"]);
+            <TabsContent value="home">
+              <HomeHighlightsWrapper emojis={emojis} mutate={mutate} highlights={data} loading={isLoading} />
+              {meta.pageCount > 1 && (
+                <div className="flex items-center justify-between max-w-3xl px-2 mt-10">
+                  <div className="flex items-center w-max gap-x-4">
+                    <PaginationResults metaInfo={meta} total={meta.itemCount} entity={"highlights"} />
+                  </div>
+                  <Pagination
+                    pages={[]}
+                    totalPage={meta.pageCount}
+                    page={meta.page}
+                    pageSize={meta.itemCount}
+                    goToPage
+                    hasNextPage={meta.hasNextPage}
+                    hasPreviousPage={meta.hasPreviousPage}
+                    onPageChange={function (page: number): void {
+                      setPage(page);
+                      if (topRef.current) {
+                        topRef.current.scrollIntoView({
+                          behavior: "smooth",
+                        });
+                      }
+                    }}
+                  />
+                </div>
+              )}
+            </TabsContent>
+            <TabsContent value="following">
+              <FollowingHighlightWrapper selectedFilter={selectedRepo} emojis={emojis} />
+            </TabsContent>
+          </Tabs>
+          <div className="lg:sticky flex-col flex-none lg:w-1/3 gap-6 lg:mt-10 xl:w-1/3 lg:flex top-20">
+            {repoList && repoList.length > 0 && (
+              <HighlightsFilterCard
+                setSelected={(repo) => {
+                  if (!openSingleHighlight) {
+                    if (repo) {
+                      setQueryParams({ repo });
+                    } else {
+                      setQueryParams({}, ["repo"]);
+                    }
+                    setPage(1);
                   }
-                  setPage(1);
-                }
-              }}
-              repos={repoList}
-              selectedFilter={selectedRepo}
-            />
-          )}
+                }}
+                repos={repoList}
+                selectedFilter={selectedRepo}
+              />
+            )}
 
-          {featuredHighlights && featuredHighlights.length > 0 && (
-            <FeaturedHighlightsPanel highlights={featuredHighlights} />
-          )}
-          <NewsletterForm />
+            {featuredHighlights && featuredHighlights.length > 0 && (
+              <FeaturedHighlightsPanel highlights={featuredHighlights} />
+            )}
+            <NewsletterForm />
+          </div>
         </div>
       </div>
     </>

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -300,7 +300,7 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
         )}
         <div className="flex flex-col w-full gap-12 md:items-start lg:flex-row">
           <Tabs onValueChange={onTabChange} defaultValue="home" className="w-full 2xl:max-w-[40rem] xl:max-w-[33rem]">
-            <TabsList className={clsx("justify-start  w-full border-b", !user && "hidden")}>
+            <TabsList className={clsx("justify-start w-full border-b", !user && "hidden")}>
               <TabsTrigger
                 className="data-[state=active]:border-sauced-orange data-[state=active]:border-b-2 text-lg"
                 value="home"


### PR DESCRIPTION
## Description

This PR brings back the panels in large screens to the smaller views of the Feed page and improves its responsivity.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

fixes #1510 

## Mobile & Desktop Screenshots/Recordings

### Repository list is now compact.
Before: 
![image](https://github.com/open-sauced/app/assets/52013393/e5a2b3a5-c4cd-4873-9b0d-1b6a30bd8a5f)

After:
![image](https://github.com/open-sauced/app/assets/52013393/fa09360e-0102-42c7-895c-8513f320a2a4)

### XS view:

https://github.com/open-sauced/app/assets/52013393/4ad2fa15-5d40-4b15-bdb2-1d48f0c6cd20

### SM & MD view:


https://github.com/open-sauced/app/assets/52013393/04fca918-e665-4e7d-b89b-6b89391edf92

## After deployment tasks

We can move Repository List filters to be above the highlights for small views, but that's for another issue.

<!-- Visual changes require screenshots -->
