### PR TITLE
fix: reset base font size in * selector in global.css

### DIFF
--- a/components/Graphs/MostUsedLanguagesGraph/most-used-languages-graph.tsx
+++ b/components/Graphs/MostUsedLanguagesGraph/most-used-languages-graph.tsx
@@ -112,15 +112,23 @@ export const MostUsedLanguagesGraph = ({
                   key={item.name}
                   className={`flex justify-between pt-4 pb-4 ${
                     index === lastItem ? "" : "border-b-1 border-slate-100"
-                  } ${language === item.name ? "font-semibold" : ""}`}
+                  }`}
                 >
                   <span
-                    className={`flex gap-2 items-center ${language === item.name ? "text-black" : "text-slate-700"}`}
+                    className={`flex gap-2 items-center ${language === item.name ? "text-black" : "text-slate-700"} ${
+                      language === item.name ? "font-semibold" : ""
+                    }`}
                   >
                     <BsFillCircleFill size={11} style={{ fill: colors[index] }} />
                     {item.name}
                   </span>
-                  <span className={`${language === item.name ? "text-black" : "text-slate-600"}`}>{item.value}%</span>
+                  <span
+                    className={`${language === item.name ? "text-black" : "text-slate-600"} ${
+                      language === item.name ? "font-semibold" : ""
+                    }`}
+                  >
+                    {item.value}%
+                  </span>
                 </li>
               ))
             ) : (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,8 +8,11 @@
   src: url("../public/assets/fonts/Inter-VariableFont_slnt,wght.ttf");
 }
 
-body {
+* {
   @apply font-normal;
+}
+
+body {
   background-color: #f8f9fa;
 }
 


### PR DESCRIPTION
## Description

While implementing the most used languages graph component, I changed how the base font
weight is set so that the font-weight would cascade instead of get reset on literally every element type.

Allowing the natural CSS cascade for the font-weight caused visual regressions. (see https://github.com/open-sauced/app/pull/2158/files#diff-4ee0e71a2145586038d583d58bcbd7aaa6b42318f417f5b62f2cbee48931861bL11-L17) I'll sync with @isabensusan about this, but we should prefer the change I made instead of setting a font-weight on `*` but it will require some more typography cleanup in the app.

**Note that this is only in beta as my PR for the most used languages graph is not in production yet.**

## What type of PR is this? (check all applicable)

- [ ] % Feature
- [x] % Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Build
- [ ] Chore (Release)
- [ ] Revert

## Related Tickets & Documents

Relates to #2158

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2023-11-19 at 16 14 52](https://github.com/open-sauced/app/assets/833231/ca26c26a-a14c-4ae9-9e1a-8f1274167069)

**After**

![CleanShot 2023-11-19 at 16 14 10](https://github.com/open-sauced/app/assets/833231/eb37cfff-d497-4538-870f-ce764385e809)

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
