### PR TITLE
feat: workspaces can manage tracked repositories now (search repos flow)

### DIFF
--- a/components/Workspaces/SearchReposTable.tsx
+++ b/components/Workspaces/SearchReposTable.tsx
@@ -11,7 +11,7 @@ interface SearchedReposTableProps {
 
 export const SearchedReposTable = ({ repositories = [], onFilter, onSelect }: SearchedReposTableProps) => {
   return (
-    <div className="border border-light-slate-7 rounded-lg max-w-lg">
+    <div className="border border-light-slate-7 rounded-lg">
       <Table className="not-sr-only">
         <TableHeader>
           <TableRow className="bg-light-slate-3">

--- a/components/Workspaces/SearchReposTable.tsx
+++ b/components/Workspaces/SearchReposTable.tsx
@@ -36,7 +36,7 @@ export const SearchedReposTable = ({ repositories = [], onFilter, onSelect }: Se
       <Table className="not-sr-only">
         <TableHeader>
           <TableRow className="bg-light-slate-3">
-            <TableHead className="flex justify-between items-center">
+            <TableHead className="flex justify-between items-center gap-6">
               Selected repositories
               <form
                 role="search"

--- a/components/Workspaces/SearchReposTable.tsx
+++ b/components/Workspaces/SearchReposTable.tsx
@@ -1,6 +1,3 @@
-import { BiBarChartAlt2 } from "react-icons/bi";
-import { FaPlus } from "react-icons/fa6";
-import Button from "components/atoms/Button/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "components/shared/Table";
 import { Avatar } from "components/atoms/Avatar/avatar-hover-card";
 import Checkbox from "components/atoms/Checkbox/checkbox";
@@ -12,27 +9,9 @@ interface SearchedReposTableProps {
   onSelect: (value: string) => void;
 }
 
-const EmptyState = ({ onAddRepos }: { onAddRepos: () => void }) => {
-  return (
-    <div className="grid place-content-center gap-4 my-8">
-      <BiBarChartAlt2 className="border rounded p-1 w-12 h-12 mx-auto" />
-      <div className="grid w-max max-w-sm mx-auto">
-        <span className="text-center text-lg font-semibold mb-2">Add repositories to track</span>
-        <p className="text-sm text-center">
-          Search and select the repositories you want to track and get insights on your entire Github ecosystem
-        </p>
-      </div>
-      <Button variant="primary" className="w-max mx-auto" onClick={onAddRepos}>
-        <FaPlus className="mr-2 text-lg" />
-        Add repositories
-      </Button>
-    </div>
-  );
-};
-
 export const SearchedReposTable = ({ repositories = [], onFilter, onSelect }: SearchedReposTableProps) => {
   return (
-    <div className="border border-light-slate-7 rounded-lg">
+    <div className="border border-light-slate-7 rounded-lg max-w-lg">
       <Table className="not-sr-only">
         <TableHeader>
           <TableRow className="bg-light-slate-3">

--- a/components/Workspaces/SearchReposTable.tsx
+++ b/components/Workspaces/SearchReposTable.tsx
@@ -7,7 +7,7 @@ import Checkbox from "components/atoms/Checkbox/checkbox";
 import Search from "components/atoms/Search/search";
 
 interface SearchedReposTableProps {
-  repositories: GhRepo[];
+  repositories: string[];
   onFilter: (filterTerm: string) => void;
   onSelect: () => void;
 }
@@ -59,13 +59,15 @@ export const SearchedReposTable = ({ repositories = [], onFilter, onSelect }: Se
           </TableHeader>
           <TableBody>
             {repositories.map((repo) => {
+              const [owner] = repo.split("/");
+
               return (
-                <TableRow key={repo.full_name}>
+                <TableRow key={repo}>
                   <TableCell className="flex gap-2 items-center w-full">
                     <label className="flex items-center gap-2">
                       <Checkbox onChange={onSelect} checked />
-                      <Avatar contributor={repo.owner.login} size="xsmall" />
-                      <span>{repo.full_name}</span>
+                      <Avatar contributor={owner} size="xsmall" />
+                      <span>{repo}</span>
                     </label>
                   </TableCell>
                 </TableRow>

--- a/components/Workspaces/SearchReposTable.tsx
+++ b/components/Workspaces/SearchReposTable.tsx
@@ -1,6 +1,5 @@
 import { BiBarChartAlt2 } from "react-icons/bi";
 import { FaPlus } from "react-icons/fa6";
-import { useState } from "react";
 import Button from "components/atoms/Button/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "components/shared/Table";
 import { Avatar } from "components/atoms/Avatar/avatar-hover-card";
@@ -8,11 +7,8 @@ import Checkbox from "components/atoms/Checkbox/checkbox";
 import Search from "components/atoms/Search/search";
 
 interface SearchedReposTableProps {
-  repositories: {
-    owner: string;
-    name: string;
-  }[];
-  onFilter: () => void;
+  repositories: GhRepo[];
+  onFilter: (filterTerm: string) => void;
   onSelect: () => void;
 }
 
@@ -34,13 +30,7 @@ const EmptyState = ({ onAddRepos }: { onAddRepos: () => void }) => {
   );
 };
 
-export const SearchedReposTable = ({
-  repositories = [],
-  onFilter,
-  onSelect: onSelectRepo,
-}: SearchedReposTableProps) => {
-  const [filteredRepositories, setFilteredRepositories] = useState(repositories);
-
+export const SearchedReposTable = ({ repositories = [], onFilter, onSelect }: SearchedReposTableProps) => {
   return (
     <div className="border border-light-slate-7 rounded-lg">
       <Table className="not-sr-only">
@@ -48,20 +38,13 @@ export const SearchedReposTable = ({
           <TableRow className="bg-light-slate-3">
             <TableHead className="flex justify-between items-center">
               Selected repositories
-              <form role="search">
-                <Search
-                  placeholder="Filter repositories"
-                  className="w-full"
-                  name="query"
-                  onChange={(search) => {
-                    setFilteredRepositories(
-                      repositories.filter((repo) => {
-                        return `${repo.owner}/${repo.name}`.includes(search);
-                      })
-                    );
-                  }}
-                  onSearch={onFilter}
-                />
+              <form
+                role="search"
+                onSubmit={(event) => {
+                  event.preventDefault;
+                }}
+              >
+                <Search placeholder="Filter repositories" className="w-full" name="query" onChange={onFilter} />
               </form>
             </TableHead>
           </TableRow>
@@ -75,16 +58,14 @@ export const SearchedReposTable = ({
             </TableRow>
           </TableHeader>
           <TableBody>
-            {filteredRepositories.map((repo) => {
-              const fullRepoName = `${repo.owner}/${repo.name}`;
-
+            {repositories.map((repo) => {
               return (
-                <TableRow key={fullRepoName}>
+                <TableRow key={repo.full_name}>
                   <TableCell className="flex gap-2 items-center w-full">
                     <label className="flex items-center gap-2">
-                      <Checkbox onChange={onSelectRepo} />
-                      <Avatar contributor={repo.owner} size="xsmall" />
-                      <span>{fullRepoName}</span>
+                      <Checkbox onChange={onSelect} checked />
+                      <Avatar contributor={repo.owner.login} size="xsmall" />
+                      <span>{repo.full_name}</span>
                     </label>
                   </TableCell>
                 </TableRow>

--- a/components/Workspaces/SearchReposTable.tsx
+++ b/components/Workspaces/SearchReposTable.tsx
@@ -9,7 +9,7 @@ import Search from "components/atoms/Search/search";
 interface SearchedReposTableProps {
   repositories: string[];
   onFilter: (filterTerm: string) => void;
-  onSelect: () => void;
+  onSelect: (value: string) => void;
 }
 
 const EmptyState = ({ onAddRepos }: { onAddRepos: () => void }) => {
@@ -65,7 +65,13 @@ export const SearchedReposTable = ({ repositories = [], onFilter, onSelect }: Se
                 <TableRow key={repo}>
                   <TableCell className="flex gap-2 items-center w-full">
                     <label className="flex items-center gap-2">
-                      <Checkbox onChange={onSelect} checked />
+                      <Checkbox
+                        onChange={(event) => {
+                          onSelect("");
+                        }}
+                        // TODO: handle checked/unchecked
+                        checked
+                      />
                       <Avatar contributor={owner} size="xsmall" />
                       <span>{repo}</span>
                     </label>

--- a/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.stories.tsx
+++ b/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.stories.tsx
@@ -7,19 +7,11 @@ const meta: Meta<typeof PickReposOrOrgStep> = {
   title: "Components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep",
   component: PickReposOrOrgStep,
   args: {
-    trackedReposCount: 0,
     onSearchRepos: () => {},
     onImportOrg: () => {},
-    onCancel: () => {},
   },
 };
 
 export default meta;
 
 export const Default: Story = {};
-
-export const SelectedRepositories: Story = {
-  args: {
-    trackedReposCount: 543,
-  },
-};

--- a/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.stories.tsx
+++ b/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof PickReposOrOrgStep> = {
   component: PickReposOrOrgStep,
   args: {
     trackedReposCount: 0,
-    onAddToTrackingList: () => {},
     onSearchRepos: () => {},
     onImportOrg: () => {},
     onCancel: () => {},

--- a/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.tsx
+++ b/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.tsx
@@ -2,7 +2,6 @@ import { FaSearch } from "react-icons/fa";
 import { FaGithub } from "react-icons/fa6";
 
 interface PickReposOrOrgStepProps {
-  onAddToTrackingList: () => void;
   onSearchRepos: () => void;
   onImportOrg: () => void;
   onCancel: () => void;
@@ -10,7 +9,6 @@ interface PickReposOrOrgStepProps {
 }
 
 export const PickReposOrOrgStep = ({
-  onAddToTrackingList,
   onSearchRepos,
   onImportOrg,
   onCancel,

--- a/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.tsx
+++ b/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.tsx
@@ -1,5 +1,7 @@
+import { useRef } from "react";
 import { FaSearch } from "react-icons/fa";
 import { FaGithub } from "react-icons/fa6";
+import { useEffectOnce } from "react-use";
 
 interface PickReposOrOrgStepProps {
   onSearchRepos: () => void;
@@ -7,10 +9,17 @@ interface PickReposOrOrgStepProps {
 }
 
 export const PickReposOrOrgStep = ({ onSearchRepos, onImportOrg }: PickReposOrOrgStepProps) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffectOnce(() => {
+    buttonRef.current?.focus();
+  });
+
   return (
     <>
       <div className="grid gap-6 md:grid-cols-2" data-tracked-repo-wizard>
         <button
+          ref={buttonRef}
           className="flex flex-col text-light-slate-12 p-8 border rounded-lg focus-visible:!border-green-800 focus-visible:!ring-green-100"
           onClick={onSearchRepos}
         >

--- a/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.tsx
+++ b/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.tsx
@@ -30,8 +30,10 @@ export const PickReposOrOrgStep = ({ onSearchRepos, onImportOrg }: PickReposOrOr
           <span className="text-left">Search for specific repositories to track on your workspace.</span>
         </button>
         <button
-          className="flex flex-col text-light-slate-12 p-8 border rounded-lg focus-visible:!border-green-800 focus-visible:!ring-green-100"
+          className="flex flex-col text-light-slate-12 p-8 border rounded-lg focus-visible:!border-green-800 focus-visible:!ring-green-100 cursor-not-allowed disabled:opacity-50"
+          title="coming soon"
           onClick={onImportOrg}
+          disabled
         >
           <FaGithub size={20} className="text-purple-800 mb-2" />
           <span data-button-title className="font-semibold">

--- a/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.tsx
+++ b/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.tsx
@@ -1,6 +1,5 @@
 import { FaSearch } from "react-icons/fa";
 import { FaGithub } from "react-icons/fa6";
-import { TrackedRepoWizardLayout } from "./TrackedRepoWizardLayout";
 
 interface PickReposOrOrgStepProps {
   onAddToTrackingList: () => void;
@@ -18,11 +17,7 @@ export const PickReposOrOrgStep = ({
   trackedReposCount,
 }: PickReposOrOrgStepProps) => {
   return (
-    <TrackedRepoWizardLayout
-      onAddToTrackingList={onAddToTrackingList}
-      trackedReposCount={trackedReposCount}
-      onCancel={onCancel}
-    >
+    <>
       <div className="grid gap-6 md:grid-cols-2" data-tracked-repo-wizard>
         <button
           className="flex flex-col text-light-slate-12 p-8 border rounded-lg focus-visible:!border-green-800 focus-visible:!ring-green-100"
@@ -45,6 +40,6 @@ export const PickReposOrOrgStep = ({
           <span className="text-left">Search for organizations on Github and import any or all repositories.</span>
         </button>
       </div>
-    </TrackedRepoWizardLayout>
+    </>
   );
 };

--- a/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.tsx
+++ b/components/Workspaces/TrackedRepoWizard/PickReposOrOrgStep.tsx
@@ -4,16 +4,9 @@ import { FaGithub } from "react-icons/fa6";
 interface PickReposOrOrgStepProps {
   onSearchRepos: () => void;
   onImportOrg: () => void;
-  onCancel: () => void;
-  trackedReposCount: number;
 }
 
-export const PickReposOrOrgStep = ({
-  onSearchRepos,
-  onImportOrg,
-  onCancel,
-  trackedReposCount,
-}: PickReposOrOrgStepProps) => {
+export const PickReposOrOrgStep = ({ onSearchRepos, onImportOrg }: PickReposOrOrgStepProps) => {
   return (
     <>
       <div className="grid gap-6 md:grid-cols-2" data-tracked-repo-wizard>

--- a/components/Workspaces/TrackedRepoWizard/SearchByReposStep.stories.tsx
+++ b/components/Workspaces/TrackedRepoWizard/SearchByReposStep.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta<typeof SearchByReposStep> = {
   component: SearchByReposStep,
   args: {
     repositories: [],
+    searchedRepos: [],
     suggestedRepos: [],
   },
 };

--- a/components/Workspaces/TrackedRepoWizard/SearchByReposStep.stories.tsx
+++ b/components/Workspaces/TrackedRepoWizard/SearchByReposStep.stories.tsx
@@ -7,9 +7,6 @@ const meta: Meta<typeof SearchByReposStep> = {
   title: "Components/Workspaces/TrackedRepoWizard/SearchByReposStep",
   component: SearchByReposStep,
   args: {
-    trackedReposCount: 0,
-    onAddToTrackingList: () => {},
-    onCancel: () => {},
     repositories: [],
     suggestedRepos: [],
   },
@@ -21,21 +18,13 @@ export const Default: Story = {};
 
 export const HasTrackedRepos: Story = {
   args: {
-    repositories: new Array(100).fill("").map((_, i) => ({
-      owner: "open-sauced",
-      name: `awesome-pizza-project-${i}`,
-    })),
-    trackedReposCount: 4,
+    repositories: new Array(100).fill("").map((_, i) => `open-sauced/awesome-pizza-project-${i}`),
   },
 };
 
 export const HasSuggestedRepos: Story = {
   args: {
     repositories: [],
-    trackedReposCount: 0,
-    suggestedRepos: new Array(3).fill("").map((_, i) => ({
-      owner: "open-sauced",
-      name: `awesome-pizza-project-${i}`,
-    })),
+    suggestedRepos: new Array(3).fill("").map((_, i) => `open-sauced/awesome-pizza-project-${i}`),
   },
 };

--- a/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
+++ b/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
@@ -58,7 +58,7 @@ export const SearchByReposStep = ({
   }, [searchedRepos]);
 
   return (
-    <div className="grid gap-6">
+    <div className="flex flex-col gap-4 h-96 max-h-96">
       <form
         ref={formRef}
         role="search"

--- a/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
+++ b/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
@@ -1,19 +1,15 @@
 import { FaSearch } from "react-icons/fa";
+import { useState } from "react";
 import Search from "components/atoms/Search/search";
 import { Avatar } from "components/atoms/Avatar/avatar-hover-card";
 import { SearchedReposTable } from "../SearchReposTable";
 
 interface SearchByReposStepProps {
   onSearch: (search?: string) => void;
-  trackedReposCount: number;
-  repositories: {
-    owner: string;
-    name: string;
-  }[];
-  suggestedRepos: {
-    owner: string;
-    name: string;
-  }[];
+  onSelectRepo: (value: string) => void;
+  repositories: GhRepo[];
+  suggestedRepos: GhRepo[];
+  searchedRepos: GhRepo[];
 }
 
 const EmptyState = () => {
@@ -32,13 +28,20 @@ const EmptyState = () => {
 
 export const SearchByReposStep = ({
   onSearch,
-  trackedReposCount,
+  onSelectRepo,
   repositories,
-  suggestedRepos,
+  searchedRepos,
+  suggestedRepos = [],
 }: SearchByReposStepProps) => {
-  // TODO: Implement these functions
-  const onFilterRepos = () => {};
-  const onSelectRepo = () => {};
+  const [filteredRepositories, setFilteredRepositories] = useState(repositories);
+
+  const onFilterRepos = (search: string) => {
+    setFilteredRepositories(
+      repositories.filter((repo) => {
+        return repo.full_name.includes(search);
+      })
+    );
+  };
 
   return (
     <div className="grid gap-6">
@@ -53,26 +56,29 @@ export const SearchByReposStep = ({
           className="w-full"
           name="query"
           onChange={onSearch}
-          suggestionsLabel="Suggested repositories"
-          suggestions={suggestedRepos.map((repo) => {
-            const fullRepoName = `${repo.owner}/${repo.name}`;
-
+          onSelect={onSelectRepo}
+          suggestionsLabel={suggestedRepos.length > 0 ? "Suggested repositories" : undefined}
+          suggestions={(suggestedRepos.length > 0 ? suggestedRepos : searchedRepos).map((repo) => {
             return {
-              key: fullRepoName,
+              key: repo.full_name,
               node: (
-                <div key={fullRepoName} className="flex items-center gap-2">
-                  <Avatar contributor={repo.owner} size="xsmall" />
-                  <span>{fullRepoName}</span>
+                <div key={repo.id} data-repo={JSON.stringify(repo)} className="flex items-center gap-2">
+                  <Avatar contributor={repo.owner.login} size="xsmall" />
+                  <span>{repo.full_name}</span>
                 </div>
               ),
             };
           })}
         />
       </form>
-      {trackedReposCount === 0 ? (
+      {repositories.length === 0 && filteredRepositories.length === 0 ? (
         <EmptyState />
       ) : (
-        <SearchedReposTable repositories={repositories} onFilter={onFilterRepos} onSelect={onSelectRepo} />
+        <SearchedReposTable
+          repositories={filteredRepositories.length > 0 ? filteredRepositories : repositories}
+          onFilter={onFilterRepos}
+          onSelect={onSelectRepo}
+        />
       )}
     </div>
   );

--- a/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
+++ b/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
@@ -2,11 +2,8 @@ import { FaSearch } from "react-icons/fa";
 import Search from "components/atoms/Search/search";
 import { Avatar } from "components/atoms/Avatar/avatar-hover-card";
 import { SearchedReposTable } from "../SearchReposTable";
-import { TrackedRepoWizardLayout } from "./TrackedRepoWizardLayout";
 
 interface SearchByReposStepProps {
-  onAddToTrackingList: () => void;
-  onCancel: () => void;
   onSearch: (search?: string) => void;
   trackedReposCount: number;
   repositories: {
@@ -34,8 +31,6 @@ const EmptyState = () => {
 };
 
 export const SearchByReposStep = ({
-  onAddToTrackingList,
-  onCancel,
   onSearch,
   trackedReposCount,
   repositories,
@@ -46,40 +41,39 @@ export const SearchByReposStep = ({
   const onSelectRepo = () => {};
 
   return (
-    <TrackedRepoWizardLayout
-      onAddToTrackingList={onAddToTrackingList}
-      onCancel={onCancel}
-      trackedReposCount={trackedReposCount}
-    >
-      <div className="grid gap-6">
-        <form role="search">
-          <Search
-            placeholder="Search repositories"
-            className="w-full"
-            name="query"
-            onSearch={onSearch}
-            suggestionsLabel="Suggested repositories"
-            suggestions={suggestedRepos.map((repo) => {
-              const fullRepoName = `${repo.owner}/${repo.name}`;
+    <div className="grid gap-6">
+      <form
+        role="search"
+        onSubmit={(e) => {
+          e.preventDefault();
+        }}
+      >
+        <Search
+          placeholder="Search repositories"
+          className="w-full"
+          name="query"
+          onChange={onSearch}
+          suggestionsLabel="Suggested repositories"
+          suggestions={suggestedRepos.map((repo) => {
+            const fullRepoName = `${repo.owner}/${repo.name}`;
 
-              return {
-                key: fullRepoName,
-                node: (
-                  <div key={fullRepoName} className="flex items-center gap-2">
-                    <Avatar contributor={repo.owner} size="xsmall" />
-                    <span>{fullRepoName}</span>
-                  </div>
-                ),
-              };
-            })}
-          />
-        </form>
-        {trackedReposCount === 0 ? (
-          <EmptyState />
-        ) : (
-          <SearchedReposTable repositories={repositories} onFilter={onFilterRepos} onSelect={onSelectRepo} />
-        )}
-      </div>
-    </TrackedRepoWizardLayout>
+            return {
+              key: fullRepoName,
+              node: (
+                <div key={fullRepoName} className="flex items-center gap-2">
+                  <Avatar contributor={repo.owner} size="xsmall" />
+                  <span>{fullRepoName}</span>
+                </div>
+              ),
+            };
+          })}
+        />
+      </form>
+      {trackedReposCount === 0 ? (
+        <EmptyState />
+      ) : (
+        <SearchedReposTable repositories={repositories} onFilter={onFilterRepos} onSelect={onSelectRepo} />
+      )}
+    </div>
   );
 };

--- a/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
+++ b/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
@@ -1,5 +1,6 @@
 import { FaSearch } from "react-icons/fa";
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { useEffectOnce } from "react-use";
 import Search from "components/atoms/Search/search";
 import { Avatar } from "components/atoms/Avatar/avatar-hover-card";
 import { SearchedReposTable } from "../SearchReposTable";
@@ -43,9 +44,16 @@ export const SearchByReposStep = ({
     );
   };
 
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffectOnce(() => {
+    (formRef.current?.querySelector('[name="query"]') as HTMLInputElement)?.focus();
+  });
+
   return (
     <div className="grid gap-6">
       <form
+        ref={formRef}
         role="search"
         onSubmit={(e) => {
           e.preventDefault();

--- a/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
+++ b/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
@@ -7,9 +7,9 @@ import { SearchedReposTable } from "../SearchReposTable";
 interface SearchByReposStepProps {
   onSearch: (search?: string) => void;
   onSelectRepo: (value: string) => void;
-  repositories: GhRepo[];
-  suggestedRepos: GhRepo[];
-  searchedRepos: GhRepo[];
+  repositories: string[];
+  suggestedRepos: string[];
+  searchedRepos: string[];
 }
 
 const EmptyState = () => {
@@ -59,12 +59,14 @@ export const SearchByReposStep = ({
           onSelect={onSelectRepo}
           suggestionsLabel={suggestedRepos.length > 0 ? "Suggested repositories" : undefined}
           suggestions={(suggestedRepos.length > 0 ? suggestedRepos : searchedRepos).map((repo) => {
+            const [owner] = repo.split("/");
+
             return {
-              key: repo.full_name,
+              key: repo,
               node: (
-                <div key={repo.id} data-repo={JSON.stringify(repo)} className="flex items-center gap-2">
-                  <Avatar contributor={repo.owner.login} size="xsmall" />
-                  <span>{repo.full_name}</span>
+                <div key={repo} className="flex items-center gap-2">
+                  <Avatar contributor={owner} size="xsmall" />
+                  <span>{repo}</span>
                 </div>
               ),
             };

--- a/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
+++ b/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
@@ -1,5 +1,5 @@
 import { FaSearch } from "react-icons/fa";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useEffectOnce } from "react-use";
 import Search from "components/atoms/Search/search";
 import { Avatar } from "components/atoms/Avatar/avatar-hover-card";
@@ -45,10 +45,17 @@ export const SearchByReposStep = ({
   };
 
   const formRef = useRef<HTMLFormElement>(null);
+  const [searchIsLoading, setSearchIsLoading] = useState(false);
 
   useEffectOnce(() => {
     (formRef.current?.querySelector('[name="query"]') as HTMLInputElement)?.focus();
   });
+
+  useEffect(() => {
+    if (searchedRepos.length > 0) {
+      setSearchIsLoading(false);
+    }
+  }, [searchedRepos]);
 
   return (
     <div className="grid gap-6">
@@ -62,8 +69,12 @@ export const SearchByReposStep = ({
         <Search
           placeholder="Search repositories"
           className="w-full"
+          isLoading={searchIsLoading}
           name="query"
-          onChange={onSearch}
+          onChange={(event) => {
+            setSearchIsLoading(true);
+            onSearch(event);
+          }}
           onSelect={onSelectRepo}
           suggestionsLabel={suggestedRepos.length > 0 ? "Suggested repositories" : undefined}
           suggestions={(suggestedRepos.length > 0 ? suggestedRepos : searchedRepos).map((repo) => {

--- a/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
+++ b/components/Workspaces/TrackedRepoWizard/SearchByReposStep.tsx
@@ -38,7 +38,7 @@ export const SearchByReposStep = ({
   const onFilterRepos = (search: string) => {
     setFilteredRepositories(
       repositories.filter((repo) => {
-        return repo.full_name.includes(search);
+        return repo.includes(search);
       })
     );
   };

--- a/components/Workspaces/TrackedRepoWizard/TrackedRepoWizard.tsx
+++ b/components/Workspaces/TrackedRepoWizard/TrackedRepoWizard.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { PickReposOrOrgStep } from "./PickReposOrOrgStep";
+import { TrackedRepoWizardLayout } from "./TrackedRepoWizardLayout";
+import { SearchByReposStep } from "./SearchByReposStep";
+
+interface TrackedReposWizardProps {
+  trackedReposCount: number;
+  onAddToTrackingList: () => void;
+  onCancel: () => void;
+  onSearchRepos: (searchTerm?: string) => void;
+}
+
+type TrackedReposStep = "pickReposOrOrg" | "pickRepos" | "pickOrg";
+
+export const TrackedReposWizard = ({
+  trackedReposCount,
+  onAddToTrackingList,
+  onCancel,
+  onSearchRepos,
+}: TrackedReposWizardProps) => {
+  const [step, setStep] = useState<TrackedReposStep>("pickReposOrOrg");
+  const repositories: any[] = [];
+  const suggestedRepos: any[] = [];
+  const onImportOrg = () => {};
+
+  const renderStep = (step: TrackedReposStep) => {
+    switch (step) {
+      case "pickReposOrOrg":
+        return (
+          <PickReposOrOrgStep
+            onAddToTrackingList={onAddToTrackingList}
+            onSearchRepos={() => {
+              setStep("pickRepos");
+            }}
+            onImportOrg={onImportOrg}
+            onCancel={onCancel}
+            trackedReposCount={trackedReposCount}
+          />
+        );
+      case "pickRepos":
+        return (
+          <SearchByReposStep
+            onSearch={onSearchRepos}
+            trackedReposCount={trackedReposCount}
+            repositories={repositories}
+            suggestedRepos={suggestedRepos}
+          />
+        );
+      // TODO: other steps
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <TrackedRepoWizardLayout
+      onAddToTrackingList={onAddToTrackingList}
+      trackedReposCount={trackedReposCount}
+      onCancel={onCancel}
+    >
+      {renderStep(step)}
+    </TrackedRepoWizardLayout>
+  );
+};

--- a/components/Workspaces/TrackedRepoWizard/TrackedRepoWizard.tsx
+++ b/components/Workspaces/TrackedRepoWizard/TrackedRepoWizard.tsx
@@ -5,7 +5,7 @@ import { TrackedRepoWizardLayout } from "./TrackedRepoWizardLayout";
 import { SearchByReposStep } from "./SearchByReposStep";
 
 interface TrackedReposWizardProps {
-  onAddToTrackingList: (repos: string[]) => void;
+  onAddToTrackingList: (repos: Set<string>) => void;
   onCancel: () => void;
 }
 
@@ -13,8 +13,7 @@ type TrackedReposStep = "pickReposOrOrg" | "pickRepos" | "pickOrg";
 
 export const TrackedReposWizard = ({ onAddToTrackingList, onCancel }: TrackedReposWizardProps) => {
   const [step, setStep] = useState<TrackedReposStep>("pickReposOrOrg");
-  // TODO: probably makes more sense as an object so it's more performant.
-  const [currentTrackedRepositories, setCurrentTrackedRepositories] = useState<string[]>([]);
+  const [currentTrackedRepositories, setCurrentTrackedRepositories] = useState<Set<string>>(new Set());
   const suggestedRepos: any[] = [];
   const onImportOrg = () => {};
   const [searchTerm, setSearchTerm] = useState<string | undefined>();
@@ -22,10 +21,12 @@ export const TrackedReposWizard = ({ onAddToTrackingList, onCancel }: TrackedRep
 
   const onSelectRepo = (repo: string) => {
     setSearchTerm(undefined);
-    setCurrentTrackedRepositories((currentTrackedRepositories) => [
-      ...currentTrackedRepositories.filter((r) => r !== repo),
-      repo,
-    ]);
+    setCurrentTrackedRepositories((currentTrackedRepositories) => {
+      const updates = new Set(currentTrackedRepositories);
+      updates.add(repo);
+
+      return updates;
+    });
   };
 
   let searchedRepos = data ?? [];
@@ -47,6 +48,8 @@ export const TrackedReposWizard = ({ onAddToTrackingList, onCancel }: TrackedRep
     }
   }
 
+  const repositories = Array.from(currentTrackedRepositories);
+
   const renderStep = (step: TrackedReposStep) => {
     switch (step) {
       case "pickReposOrOrg":
@@ -63,7 +66,7 @@ export const TrackedReposWizard = ({ onAddToTrackingList, onCancel }: TrackedRep
           <SearchByReposStep
             onSelectRepo={onSelectRepo}
             onSearch={onSearchRepos}
-            repositories={currentTrackedRepositories}
+            repositories={repositories}
             searchedRepos={searchedRepos}
             suggestedRepos={suggestedRepos}
           />
@@ -79,7 +82,7 @@ export const TrackedReposWizard = ({ onAddToTrackingList, onCancel }: TrackedRep
       onAddToTrackingList={() => {
         onAddToTrackingList(currentTrackedRepositories);
       }}
-      trackedReposCount={currentTrackedRepositories.length}
+      trackedReposCount={currentTrackedRepositories.size}
       onCancel={() => {
         goBack();
       }}

--- a/components/Workspaces/TrackedRepoWizard/TrackedRepoWizard.tsx
+++ b/components/Workspaces/TrackedRepoWizard/TrackedRepoWizard.tsx
@@ -20,14 +20,12 @@ export const TrackedReposWizard = ({ onAddToTrackingList, onCancel }: TrackedRep
   const [searchTerm, setSearchTerm] = useState<string | undefined>();
   // const { sessionToken } = useSupabaseAuth();
   const { data, isError, isLoading } = useSearchRepos(searchTerm, "" /* sessionToken */);
-  const [trackedReposCount, setTrackedReposCount] = useState(0);
 
   const onSelectRepo = (repo: string) => {
     setCurrentTrackedRepositories((currentTrackedRepositories) => [
       ...currentTrackedRepositories.filter((r) => r !== repo),
       repo,
     ]);
-    setTrackedReposCount((value) => value + 1);
   };
 
   let searchedRepos = data ?? [];
@@ -58,8 +56,6 @@ export const TrackedReposWizard = ({ onAddToTrackingList, onCancel }: TrackedRep
               setStep("pickRepos");
             }}
             onImportOrg={onImportOrg}
-            onCancel={onCancel}
-            trackedReposCount={trackedReposCount}
           />
         );
       case "pickRepos":
@@ -83,7 +79,7 @@ export const TrackedReposWizard = ({ onAddToTrackingList, onCancel }: TrackedRep
       onAddToTrackingList={() => {
         onAddToTrackingList(currentTrackedRepositories);
       }}
-      trackedReposCount={trackedReposCount}
+      trackedReposCount={currentTrackedRepositories.length}
       onCancel={() => {
         goBack();
       }}

--- a/components/Workspaces/TrackedRepoWizard/TrackedRepoWizard.tsx
+++ b/components/Workspaces/TrackedRepoWizard/TrackedRepoWizard.tsx
@@ -18,7 +18,6 @@ export const TrackedReposWizard = ({ onAddToTrackingList, onCancel }: TrackedRep
   const suggestedRepos: any[] = [];
   const onImportOrg = () => {};
   const [searchTerm, setSearchTerm] = useState<string | undefined>();
-  // const { sessionToken } = useSupabaseAuth();
   const { data, isError, isLoading } = useSearchRepos(searchTerm, "" /* sessionToken */);
 
   const onSelectRepo = (repo: string) => {

--- a/components/Workspaces/TrackedRepoWizard/TrackedRepoWizard.tsx
+++ b/components/Workspaces/TrackedRepoWizard/TrackedRepoWizard.tsx
@@ -22,6 +22,7 @@ export const TrackedReposWizard = ({ onAddToTrackingList, onCancel }: TrackedRep
   const { data, isError, isLoading } = useSearchRepos(searchTerm, "" /* sessionToken */);
 
   const onSelectRepo = (repo: string) => {
+    setSearchTerm(undefined);
     setCurrentTrackedRepositories((currentTrackedRepositories) => [
       ...currentTrackedRepositories.filter((r) => r !== repo),
       repo,

--- a/components/Workspaces/TrackedRepoWizard/TrackedRepoWizard.tsx
+++ b/components/Workspaces/TrackedRepoWizard/TrackedRepoWizard.tsx
@@ -7,21 +7,33 @@ interface TrackedReposWizardProps {
   trackedReposCount: number;
   onAddToTrackingList: () => void;
   onCancel: () => void;
-  onSearchRepos: (searchTerm?: string) => void;
 }
 
 type TrackedReposStep = "pickReposOrOrg" | "pickRepos" | "pickOrg";
 
-export const TrackedReposWizard = ({
-  trackedReposCount,
-  onAddToTrackingList,
-  onCancel,
-  onSearchRepos,
-}: TrackedReposWizardProps) => {
+export const TrackedReposWizard = ({ trackedReposCount, onAddToTrackingList, onCancel }: TrackedReposWizardProps) => {
   const [step, setStep] = useState<TrackedReposStep>("pickReposOrOrg");
   const repositories: any[] = [];
   const suggestedRepos: any[] = [];
   const onImportOrg = () => {};
+  const [searchedRepos, setSearchedRepos] = useState<GhRepo[]>([]);
+  const [searchTerm, setSearchTerm] = useState<string | undefined>();
+  // const { sessionToken } = useSupabaseAuth();
+
+  // const { data, isError, isLoading } = useSearchRepos(searchTerm, sessionToken);
+
+  function goBack() {
+    switch (step) {
+      case "pickReposOrOrg":
+        onCancel();
+      default:
+        setStep("pickReposOrOrg");
+    }
+  }
+
+  function onSearchRepos(searchTerm?: string) {
+    setSearchTerm(searchTerm);
+  }
 
   const renderStep = (step: TrackedReposStep) => {
     switch (step) {
@@ -56,7 +68,9 @@ export const TrackedReposWizard = ({
     <TrackedRepoWizardLayout
       onAddToTrackingList={onAddToTrackingList}
       trackedReposCount={trackedReposCount}
-      onCancel={onCancel}
+      onCancel={() => {
+        goBack();
+      }}
     >
       {renderStep(step)}
     </TrackedRepoWizardLayout>

--- a/components/Workspaces/TrackedRepoWizard/TrackedRepoWizardLayout.tsx
+++ b/components/Workspaces/TrackedRepoWizard/TrackedRepoWizardLayout.tsx
@@ -17,7 +17,12 @@ export const TrackedRepoWizardLayout = ({
 }: TrackedRepoWizardLayoutProps) => {
   return (
     <Card className="p-0 max-w-3xl">
-      <button className="flex gap-1 items-center ml-4 mt-4 border border-transparent" onClick={onCancel}>
+      <button
+        className="flex gap-1 items-center ml-4 mt-4 border border-transparent"
+        onClick={() => {
+          onCancel();
+        }}
+      >
         <FaArrowLeft /> back
       </button>
       <div className="flex flex-col justify-between gap-4">

--- a/components/Workspaces/TrackedRepoWizard/TrackedRepoWizardLayout.tsx
+++ b/components/Workspaces/TrackedRepoWizard/TrackedRepoWizardLayout.tsx
@@ -16,33 +16,36 @@ export const TrackedRepoWizardLayout = ({
   children,
 }: TrackedRepoWizardLayoutProps) => {
   return (
-    <Card className="p-0 max-w-3xl">
-      <button
-        className="flex gap-1 items-center ml-4 mt-4 border border-transparent"
-        onClick={() => {
-          onCancel();
-        }}
-      >
-        <FaArrowLeft /> back
-      </button>
-      <div className="flex flex-col justify-between gap-4">
-        <div className="px-4 pt-2">
-          <h2 className="font-semibold mb-4">Add repositories to track</h2>
-          {children}
-        </div>
-        <div className="flex gap-4 items-center justify-end border-t-1 p-4">
-          <span>
-            <span className="font-semibold">{trackedReposCount}</span> Selected repositories
-          </span>
-          <Button
-            variant="primary"
-            onClick={() => {
-              onAddToTrackingList();
-            }}
-            disabled={trackedReposCount === 0}
-          >
-            Add to tracking list
-          </Button>
+    <Card className="!p-0 max-w-3xl">
+      {/* Using !p-0 for now as the Card component has explicit padding of p-3. We can revisit. */}
+      <div style={{ minWidth: "712px" }}>
+        <button
+          className="flex gap-1 items-center ml-4 mt-4 border border-transparent"
+          onClick={() => {
+            onCancel();
+          }}
+        >
+          <FaArrowLeft /> back
+        </button>
+        <div className="flex flex-col justify-between gap-4">
+          <div className="px-4 pt-2">
+            <h2 className="font-semibold mb-4">Add repositories to track</h2>
+            {children}
+          </div>
+          <div className="flex gap-4 items-center justify-end border-t-1 p-4">
+            <span>
+              <span className="font-semibold">{trackedReposCount}</span> Selected repositories
+            </span>
+            <Button
+              variant="primary"
+              onClick={() => {
+                onAddToTrackingList();
+              }}
+              disabled={trackedReposCount === 0}
+            >
+              Add to tracking list
+            </Button>
+          </div>
         </div>
       </div>
     </Card>

--- a/components/Workspaces/TrackedReposModal.tsx
+++ b/components/Workspaces/TrackedReposModal.tsx
@@ -4,7 +4,7 @@ import { TrackedReposWizard } from "./TrackedRepoWizard/TrackedRepoWizard";
 interface TrackedReposModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onAddToTrackingList: () => void;
+  onAddToTrackingList: (repos: string[]) => void;
   onCancel: () => void;
 }
 

--- a/components/Workspaces/TrackedReposModal.tsx
+++ b/components/Workspaces/TrackedReposModal.tsx
@@ -1,0 +1,41 @@
+import { Dialog, DialogContent } from "components/molecules/Dialog/dialog";
+import { TrackedReposWizard } from "./TrackedRepoWizard/TrackedRepoWizard";
+
+interface TrackedReposModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  trackedReposCount: number;
+  onAddToTrackingList: () => void;
+  onSearchRepos: (searchTerm: string) => void;
+  onCancel: () => void;
+}
+
+const TrackedReposModal = ({
+  isOpen,
+  onClose,
+  trackedReposCount,
+  onAddToTrackingList,
+  onSearchRepos,
+  onCancel,
+}: TrackedReposModalProps) => {
+  const isLoading = false;
+
+  const onCloseModal = () => {
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen}>
+      <DialogContent autoStyle={false} onEscapeKeyDown={onCloseModal}>
+        <TrackedReposWizard
+          trackedReposCount={trackedReposCount}
+          onAddToTrackingList={onAddToTrackingList}
+          onSearchRepos={onSearchRepos}
+          onCancel={onCancel}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default TrackedReposModal;

--- a/components/Workspaces/TrackedReposModal.tsx
+++ b/components/Workspaces/TrackedReposModal.tsx
@@ -4,7 +4,7 @@ import { TrackedReposWizard } from "./TrackedRepoWizard/TrackedRepoWizard";
 interface TrackedReposModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onAddToTrackingList: (repos: string[]) => void;
+  onAddToTrackingList: (repos: Set<string>) => void;
   onCancel: () => void;
 }
 

--- a/components/Workspaces/TrackedReposModal.tsx
+++ b/components/Workspaces/TrackedReposModal.tsx
@@ -6,7 +6,6 @@ interface TrackedReposModalProps {
   onClose: () => void;
   trackedReposCount: number;
   onAddToTrackingList: () => void;
-  onSearchRepos: (searchTerm: string) => void;
   onCancel: () => void;
 }
 
@@ -15,11 +14,8 @@ const TrackedReposModal = ({
   onClose,
   trackedReposCount,
   onAddToTrackingList,
-  onSearchRepos,
   onCancel,
 }: TrackedReposModalProps) => {
-  const isLoading = false;
-
   const onCloseModal = () => {
     onClose();
   };
@@ -30,7 +26,6 @@ const TrackedReposModal = ({
         <TrackedReposWizard
           trackedReposCount={trackedReposCount}
           onAddToTrackingList={onAddToTrackingList}
-          onSearchRepos={onSearchRepos}
           onCancel={onCancel}
         />
       </DialogContent>

--- a/components/Workspaces/TrackedReposModal.tsx
+++ b/components/Workspaces/TrackedReposModal.tsx
@@ -4,18 +4,11 @@ import { TrackedReposWizard } from "./TrackedRepoWizard/TrackedRepoWizard";
 interface TrackedReposModalProps {
   isOpen: boolean;
   onClose: () => void;
-  trackedReposCount: number;
   onAddToTrackingList: () => void;
   onCancel: () => void;
 }
 
-const TrackedReposModal = ({
-  isOpen,
-  onClose,
-  trackedReposCount,
-  onAddToTrackingList,
-  onCancel,
-}: TrackedReposModalProps) => {
+const TrackedReposModal = ({ isOpen, onClose, onAddToTrackingList, onCancel }: TrackedReposModalProps) => {
   const onCloseModal = () => {
     onClose();
   };
@@ -23,11 +16,7 @@ const TrackedReposModal = ({
   return (
     <Dialog open={isOpen}>
       <DialogContent autoStyle={false} onEscapeKeyDown={onCloseModal}>
-        <TrackedReposWizard
-          trackedReposCount={trackedReposCount}
-          onAddToTrackingList={onAddToTrackingList}
-          onCancel={onCancel}
-        />
+        <TrackedReposWizard onAddToTrackingList={onAddToTrackingList} onCancel={onCancel} />
       </DialogContent>
     </Dialog>
   );

--- a/components/Workspaces/TrackedReposTable.stories.tsx
+++ b/components/Workspaces/TrackedReposTable.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof TrackedReposTable> = {
   title: "Components/Workspaces/TrackedReposTable",
   component: TrackedReposTable,
   args: {
-    repositories: [],
+    repositories: new Set(),
     onAddRepos: () => {
       // eslint-disable-next-line no-console
       console.log("add repos");
@@ -23,7 +23,11 @@ export default meta;
 
 export const WithRepos: Story = {
   args: {
-    repositories: new Array(100).fill("").map((_, i) => `open-sauced/awesome-pizza-project-${i}`),
+    repositories: new Set(
+      Array(100)
+        .fill("")
+        .map((_, i) => `open-sauced/awesome-pizza-project-${i}`)
+    ),
   },
 };
 

--- a/components/Workspaces/TrackedReposTable.stories.tsx
+++ b/components/Workspaces/TrackedReposTable.stories.tsx
@@ -28,3 +28,9 @@ export const WithRepos: Story = {
 };
 
 export const EmpytState: Story = {};
+
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+  },
+};

--- a/components/Workspaces/TrackedReposTable.stories.tsx
+++ b/components/Workspaces/TrackedReposTable.stories.tsx
@@ -23,10 +23,7 @@ export default meta;
 
 export const WithRepos: Story = {
   args: {
-    repositories: new Array(100).fill("").map((_, i) => ({
-      owner: "open-sauced",
-      name: `awesome-pizza-project-${i}`,
-    })),
+    repositories: new Array(100).fill("").map((_, i) => `open-sauced/awesome-pizza-project-${i}`),
   },
 };
 

--- a/components/Workspaces/TrackedReposTable.tsx
+++ b/components/Workspaces/TrackedReposTable.tsx
@@ -67,7 +67,7 @@ export const TrackedReposTable = ({
           Add repositories
         </Button>
       </div>
-      <div className="border border-light-slate-7 rounded">
+      <div className="border border-light-slate-7 rounded h-full">
         <Table className="not-sr-only">
           <TableHeader>
             <TableRow className=" bg-light-slate-3">

--- a/components/Workspaces/TrackedReposTable.tsx
+++ b/components/Workspaces/TrackedReposTable.tsx
@@ -4,6 +4,7 @@ import { FaTrashAlt } from "react-icons/fa";
 import Button from "components/atoms/Button/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "components/shared/Table";
 import { Avatar } from "components/atoms/Avatar/avatar-hover-card";
+import ClientOnly from "components/atoms/ClientOnly/client-only";
 
 interface TrackedReposTableProps {
   repositories: string[];
@@ -55,41 +56,43 @@ export const TrackedReposTable = ({ repositories, onAddRepos, onRemoveTrackedRep
             </TableRow>
           </TableHeader>
         </Table>
-        {repositories.length > 0 ? (
-          <div className="overflow-y-scroll h-60">
-            <Table>
-              <TableHeader className="sr-only">
-                <TableRow className=" bg-light-slate-3">
-                  <TableHead>Name</TableHead>
-                  <TableHead className="w-4">
-                    <span className="sr-only">Delete</span>
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {repositories.map((repo) => {
-                  const [owner] = repo.split("/");
+        <ClientOnly>
+          {repositories.length > 0 ? (
+            <div className="overflow-y-scroll h-60">
+              <Table>
+                <TableHeader className="sr-only">
+                  <TableRow className=" bg-light-slate-3">
+                    <TableHead>Name</TableHead>
+                    <TableHead className="w-4">
+                      <span className="sr-only">Delete</span>
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {repositories.map((repo) => {
+                    const [owner] = repo.split("/");
 
-                  return (
-                    <TableRow key={repo}>
-                      <TableCell className="flex gap-2 items-center w-full">
-                        <Avatar contributor={owner} size="xsmall" />
-                        <span>{repo}</span>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <button onClick={onRemoveTrackedRepo}>
-                          <FaTrashAlt title="delete" className="text-light-slate-10" />
-                        </button>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </div>
-        ) : (
-          <EmptyState onAddRepos={onAddRepos} />
-        )}
+                    return (
+                      <TableRow key={repo}>
+                        <TableCell className="flex gap-2 items-center w-full">
+                          <Avatar contributor={owner} size="xsmall" />
+                          <span>{repo}</span>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <button onClick={onRemoveTrackedRepo}>
+                            <FaTrashAlt title="delete" className="text-light-slate-10" />
+                          </button>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          ) : (
+            <EmptyState onAddRepos={onAddRepos} />
+          )}
+        </ClientOnly>
       </div>
     </div>
   );

--- a/components/Workspaces/TrackedReposTable.tsx
+++ b/components/Workspaces/TrackedReposTable.tsx
@@ -36,7 +36,7 @@ const EmptyState = ({ onAddRepos }: { onAddRepos: () => void }) => {
 const LoadingState = () => {
   return (
     <>
-      {Array.from({ length: 5 }).map((_, index) => (
+      {Array.from({ length: 5 }, (_, index) => (
         <TableRow key={index}>
           <TableCell colSpan={2}>
             <SkeletonWrapper key={index} height={22} />

--- a/components/Workspaces/TrackedReposTable.tsx
+++ b/components/Workspaces/TrackedReposTable.tsx
@@ -6,11 +6,13 @@ import Button from "components/atoms/Button/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "components/shared/Table";
 import { Avatar } from "components/atoms/Avatar/avatar-hover-card";
 import ClientOnly from "components/atoms/ClientOnly/client-only";
+import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
 
 interface TrackedReposTableProps {
   repositories: string[];
   onAddRepos: () => void;
   onRemoveTrackedRepo: ComponentProps<"button">["onClick"];
+  isLoading?: boolean;
 }
 
 const EmptyState = ({ onAddRepos }: { onAddRepos: () => void }) => {
@@ -31,7 +33,26 @@ const EmptyState = ({ onAddRepos }: { onAddRepos: () => void }) => {
   );
 };
 
-export const TrackedReposTable = ({ repositories, onAddRepos, onRemoveTrackedRepo }: TrackedReposTableProps) => {
+const LoadingState = () => {
+  return (
+    <>
+      {Array.from({ length: 5 }).map((_, index) => (
+        <TableRow key={index}>
+          <TableCell colSpan={2}>
+            <SkeletonWrapper key={index} height={22} />
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  );
+};
+
+export const TrackedReposTable = ({
+  repositories,
+  onAddRepos,
+  onRemoveTrackedRepo,
+  isLoading = false,
+}: TrackedReposTableProps) => {
   return (
     <div className="grid gap-4">
       <div className="flex justify-between">
@@ -58,7 +79,7 @@ export const TrackedReposTable = ({ repositories, onAddRepos, onRemoveTrackedRep
           </TableHeader>
         </Table>
         <ClientOnly>
-          {repositories.length > 0 ? (
+          {repositories.length > 0 || isLoading ? (
             <div className="overflow-y-scroll h-60">
               <Table>
                 <TableHeader className="sr-only">
@@ -70,23 +91,29 @@ export const TrackedReposTable = ({ repositories, onAddRepos, onRemoveTrackedRep
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {repositories.map((repo) => {
-                    const [owner] = repo.split("/");
+                  {isLoading ? (
+                    <LoadingState />
+                  ) : (
+                    <>
+                      {repositories.map((repo) => {
+                        const [owner] = repo.split("/");
 
-                    return (
-                      <TableRow key={repo}>
-                        <TableCell className="flex gap-2 items-center w-full">
-                          <Avatar contributor={owner} size="xsmall" />
-                          <span>{repo}</span>
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <button onClick={onRemoveTrackedRepo} data-repo={repo}>
-                            <FaTrashAlt title="delete" className="text-light-slate-10" />
-                          </button>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
+                        return (
+                          <TableRow key={repo}>
+                            <TableCell className="flex gap-2 items-center w-full">
+                              <Avatar contributor={owner} size="xsmall" />
+                              <span>{repo}</span>
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <button onClick={onRemoveTrackedRepo} data-repo={repo}>
+                                <FaTrashAlt title="delete" className="text-light-slate-10" />
+                              </button>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </>
+                  )}
                 </TableBody>
               </Table>
             </div>

--- a/components/Workspaces/TrackedReposTable.tsx
+++ b/components/Workspaces/TrackedReposTable.tsx
@@ -9,7 +9,7 @@ import ClientOnly from "components/atoms/ClientOnly/client-only";
 import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
 
 interface TrackedReposTableProps {
-  repositories: string[];
+  repositories: Set<string>;
   onAddRepos: () => void;
   onRemoveTrackedRepo: ComponentProps<"button">["onClick"];
   isLoading?: boolean;
@@ -79,7 +79,7 @@ export const TrackedReposTable = ({
           </TableHeader>
         </Table>
         <ClientOnly>
-          {repositories.length > 0 || isLoading ? (
+          {repositories.size > 0 || isLoading ? (
             <div className="overflow-y-scroll h-60">
               <Table>
                 <TableHeader className="sr-only">
@@ -95,7 +95,7 @@ export const TrackedReposTable = ({
                     <LoadingState />
                   ) : (
                     <>
-                      {repositories.map((repo) => {
+                      {[...repositories].map((repo) => {
                         const [owner] = repo.split("/");
 
                         return (

--- a/components/Workspaces/TrackedReposTable.tsx
+++ b/components/Workspaces/TrackedReposTable.tsx
@@ -1,6 +1,7 @@
 import { BiBarChartAlt2 } from "react-icons/bi";
 import { FaPlus } from "react-icons/fa6";
 import { FaTrashAlt } from "react-icons/fa";
+import { ComponentProps } from "react";
 import Button from "components/atoms/Button/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "components/shared/Table";
 import { Avatar } from "components/atoms/Avatar/avatar-hover-card";
@@ -9,7 +10,7 @@ import ClientOnly from "components/atoms/ClientOnly/client-only";
 interface TrackedReposTableProps {
   repositories: string[];
   onAddRepos: () => void;
-  onRemoveTrackedRepo: () => void;
+  onRemoveTrackedRepo: ComponentProps<"button">["onClick"];
 }
 
 const EmptyState = ({ onAddRepos }: { onAddRepos: () => void }) => {
@@ -79,7 +80,7 @@ export const TrackedReposTable = ({ repositories, onAddRepos, onRemoveTrackedRep
                           <span>{repo}</span>
                         </TableCell>
                         <TableCell className="text-right">
-                          <button onClick={onRemoveTrackedRepo}>
+                          <button onClick={onRemoveTrackedRepo} data-repo={repo}>
                             <FaTrashAlt title="delete" className="text-light-slate-10" />
                           </button>
                         </TableCell>

--- a/components/Workspaces/TrackedReposTable.tsx
+++ b/components/Workspaces/TrackedReposTable.tsx
@@ -6,10 +6,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "c
 import { Avatar } from "components/atoms/Avatar/avatar-hover-card";
 
 interface TrackedReposTableProps {
-  repositories: {
-    owner: string;
-    name: string;
-  }[];
+  repositories: string[];
   onAddRepos: () => void;
   onRemoveTrackedRepo: () => void;
 }
@@ -71,13 +68,13 @@ export const TrackedReposTable = ({ repositories, onAddRepos, onRemoveTrackedRep
               </TableHeader>
               <TableBody>
                 {repositories.map((repo) => {
-                  const fullRepoName = `${repo.owner}/${repo.name}`;
+                  const [owner] = repo.split("/");
 
                   return (
-                    <TableRow key={fullRepoName}>
+                    <TableRow key={repo}>
                       <TableCell className="flex gap-2 items-center w-full">
-                        <Avatar contributor={repo.owner} size="xsmall" />
-                        <span>{fullRepoName}</span>
+                        <Avatar contributor={owner} size="xsmall" />
+                        <span>{repo}</span>
                       </TableCell>
                       <TableCell className="text-right">
                         <button onClick={onRemoveTrackedRepo}>

--- a/components/Workspaces/WorkspaceLayout.tsx
+++ b/components/Workspaces/WorkspaceLayout.tsx
@@ -18,7 +18,7 @@ export const WorkspaceLayout = ({ children }: { children: React.ReactNode }) => 
       <div style={{ gridArea: "sidebar" }}>
         <AppSideBar />
       </div>
-      <div className="px-8 pt-8" style={{ gridArea: "main" }}>
+      <div className="px-8 pt-8 pb-20" style={{ gridArea: "main" }}>
         {children}
       </div>
     </div>

--- a/components/atoms/Search/search.tsx
+++ b/components/atoms/Search/search.tsx
@@ -150,7 +150,7 @@ const Search = ({
                 key={index}
                 data-suggestion={typeof suggestion === "string" ? suggestion : suggestion.key}
                 onClick={(event) => {
-                  const { suggestion } = (event.target as HTMLElement).dataset;
+                  const { suggestion } = (event.currentTarget as HTMLElement).dataset;
                   suggestion && handleOnSelect(suggestion);
                 }}
               >

--- a/components/molecules/Dialog/dialog.tsx
+++ b/components/molecules/Dialog/dialog.tsx
@@ -46,14 +46,16 @@ const DialogCloseButton = ({ onClick }: CloseButtonProps) => {
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, onClick, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { autoStyle?: boolean }
+>(({ className, children, onClick, autoStyle = true, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
       className={clsx(
-        "fixed z-50 w-full pb-3 gap-4 bg-light-slate-2 lg:p-6 animate-in data-[state=open]:fade-in-90 data-[state=open]:slide-in-from-bottom-10 md:w-max rounded-lg sm:zoom-in-90 data-[state=open]:sm:slide-in-from-bottom-0",
+        "fixed z-50",
+        autoStyle &&
+          "w-full pb-3 gap-4 bg-light-slate-2 lg:p-6 animate-in data-[state=open]:fade-in-90 data-[state=open]:slide-in-from-bottom-10 md:w-max rounded-lg sm:zoom-in-90 data-[state=open]:sm:slide-in-from-bottom-0",
         className
       )}
       {...props}

--- a/components/shared/AppSidebar/AppSidebar.tsx
+++ b/components/shared/AppSidebar/AppSidebar.tsx
@@ -107,11 +107,11 @@ export const AppSideBar = () => {
           <BiHomeAlt className="w-5 h-5 text-slate-400" />
           Home
         </h2>
-        <h3 className="uppercase text-gray-500 text-sm font-medium">Repo Insights</h3>
+        <h3 className="uppercase text-gray-500 text-sm font-medium">Repository Insights</h3>
         <div className="w-full px-2 -mt-4">
           {insightsLoading ? null : <InsightsList username={username} insights={repoInsights} type="repo" />}
         </div>
-        <h2 className="uppercase text-gray-500 text-sm font-medium">Contributor Insights</h2>
+        <h3 className="uppercase text-gray-500 text-sm font-medium">Contributor Insights</h3>
         <div className="w-full px-2 -mt-4">
           {insightsLoading ? null : <InsightsList username={username} insights={contributorInsights} type="list" />}
         </div>

--- a/components/shared/AppSidebar/AppSidebar.tsx
+++ b/components/shared/AppSidebar/AppSidebar.tsx
@@ -3,39 +3,22 @@ import { useRouter } from "next/router";
 import { LifebuoyIcon, Cog8ToothIcon } from "@heroicons/react/24/outline";
 import { BiHomeAlt } from "react-icons/bi";
 import { useEffectOnce } from "react-use";
+
 import useWorkspaces from "lib/hooks/api/useWorkspaces";
-import SidebarMenuItem from "components/shared/AppSidebar/sidebar-menu-item";
 
 import useUserInsights from "lib/hooks/useUserInsights";
 import { useFetchAllLists } from "lib/hooks/useList";
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
 import SingleSelect from "components/atoms/Select/single-select";
 import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
+import { InsightsPanel } from "./InsightsPanel";
+import SidebarMenuItem from "./sidebar-menu-item";
 
 const SidebarLoader = () => {
   return (
     <>
       <SkeletonWrapper height={20} radius={5} count={2} classNames="w-48" />
       <SkeletonWrapper height={20} radius={5} count={1} classNames="w-28" />
-    </>
-  );
-};
-
-const InsightsList = ({
-  username,
-  insights,
-  type,
-}: {
-  username: string | null;
-  insights: DbUserList[] | DbUserInsight[];
-  type: "list" | "repo";
-}) => {
-  return (
-    <>
-      {insights.map((insight) => {
-        const url = type === "list" ? `/lists/${insight.id}` : `/pages/${username}/${insight.id}/dashboard`;
-        return <SidebarMenuItem key={insight.id} title={insight.name} href={url} type={type} />;
-      })}
     </>
   );
 };
@@ -107,25 +90,31 @@ export const AppSideBar = () => {
           <BiHomeAlt className="w-5 h-5 text-slate-400" />
           Home
         </h2>
-        <h3 className="uppercase text-gray-500 text-sm font-medium">Repository Insights</h3>
-        <div className="w-full px-2 -mt-4">
-          {insightsLoading ? null : <InsightsList username={username} insights={repoInsights} type="repo" />}
-        </div>
-        <h3 className="uppercase text-gray-500 text-sm font-medium">Contributor Insights</h3>
-        <div className="w-full px-2 -mt-4">
-          {insightsLoading ? null : <InsightsList username={username} insights={contributorInsights} type="list" />}
-        </div>
+        <InsightsPanel
+          title="Repository Insights"
+          username={username}
+          insights={repoInsights}
+          type="repo"
+          isLoading={insightsLoading}
+        />
+        <InsightsPanel
+          title="Contributor Insights"
+          username={username}
+          insights={contributorInsights}
+          type="list"
+          isLoading={insightsLoading}
+        />
 
         <h3 className="uppercase text-gray-500 text-sm font-medium">Shared with you</h3>
       </div>
-      <div className="mb-4">
+      <ul className="list-none mb-4">
         <SidebarMenuItem title="Support" href="/logout" icon={<LifebuoyIcon className="w-5 h-5 text-slate-400" />} />
         <SidebarMenuItem
           title="Settings"
           href="/user/settings"
           icon={<Cog8ToothIcon className="w-5 h-5 text-slate-400" />}
         />
-      </div>
+      </ul>
     </div>
   );
 };

--- a/components/shared/AppSidebar/AppSidebar.tsx
+++ b/components/shared/AppSidebar/AppSidebar.tsx
@@ -9,7 +9,6 @@ import useUserInsights from "lib/hooks/useUserInsights";
 import { useFetchAllLists } from "lib/hooks/useList";
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
 import SingleSelect from "components/atoms/Select/single-select";
-import ClientOnly from "components/atoms/ClientOnly/client-only";
 import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
 import store from "lib/store";
 
@@ -67,29 +66,27 @@ export const AppSideBar = () => {
       <div className="grid gap-4 mt-4 px-4">
         <label className="flex flex-col gap-2 w-max">
           <span className="sr-only">Workspace</span>
-          <ClientOnly>
-            <SingleSelect
-              options={[
-                { label: "Create new workspace...", value: "new" },
-                ...workspaces.map(({ id, name }) => ({
-                  label: name,
-                  value: id,
-                })),
-              ]}
-              position="popper"
-              value={workspaceId}
-              placeholder="Select a workspace"
-              onValueChange={(value) => {
-                if (value === "new") {
-                  router.push("/workspaces/new");
-                  return;
-                }
+          <SingleSelect
+            options={[
+              { label: "Create new workspace...", value: "new" },
+              ...workspaces.map(({ id, name }) => ({
+                label: name,
+                value: id,
+              })),
+            ]}
+            position="popper"
+            value={workspaceId}
+            placeholder="Select a workspace"
+            onValueChange={(value) => {
+              if (value === "new") {
+                router.push("/workspaces/new");
+                return;
+              }
 
-                setWorkspaceId(value);
-                window.location.href = `/workspaces/${value}/settings`;
-              }}
-            />
-          </ClientOnly>
+              setWorkspaceId(value);
+              window.location.href = `/workspaces/${value}/settings`;
+            }}
+          />
         </label>
         <h2 className="flex gap-1 items-center">
           <BiHomeAlt className="w-5 h-5 text-slate-400" />

--- a/components/shared/AppSidebar/AppSidebar.tsx
+++ b/components/shared/AppSidebar/AppSidebar.tsx
@@ -108,10 +108,10 @@ export const AppSideBar = () => {
         <h3 className="uppercase text-gray-500 text-sm font-medium">Shared with you</h3>
       </div>
       <ul className="list-none mb-4">
-        <SidebarMenuItem title="Support" href="/logout" icon={<LifebuoyIcon className="w-5 h-5 text-slate-400" />} />
+        <SidebarMenuItem title="Support" url="/logout" icon={<LifebuoyIcon className="w-5 h-5 text-slate-400" />} />
         <SidebarMenuItem
           title="Settings"
-          href="/user/settings"
+          url="/user/settings"
           icon={<Cog8ToothIcon className="w-5 h-5 text-slate-400" />}
         />
       </ul>

--- a/components/shared/AppSidebar/AppSidebar.tsx
+++ b/components/shared/AppSidebar/AppSidebar.tsx
@@ -60,7 +60,7 @@ export const AppSideBar = () => {
   });
 
   return (
-    <div className="fixed top-0 pt-12 bg-white flex flex-col gap-8 justify-between min-w-max min-h-full">
+    <div className="fixed top-0 pt-12 bg-white flex flex-col gap-8 justify-between max-w-xs w-80 h-full">
       <div className="grid gap-4 mt-4 px-4">
         <label className="flex flex-col gap-2 w-max">
           <span className="sr-only">Workspace</span>

--- a/components/shared/AppSidebar/InsightsPanel.stories.tsx
+++ b/components/shared/AppSidebar/InsightsPanel.stories.tsx
@@ -1,0 +1,72 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { InsightsPanel } from "./InsightsPanel";
+
+type Story = StoryObj<typeof InsightsPanel>;
+
+const meta: Meta<typeof InsightsPanel> = {
+  title: "Components/Workspaces/InsightsPanel",
+  component: InsightsPanel,
+  args: {
+    isLoading: false,
+  },
+};
+
+export default meta;
+
+export const RepositoryInsights: Story = {
+  args: {
+    title: "Repository Insights",
+    username: "bdougie",
+    insights: new Array(5).fill("").map((_, i) => {
+      return {
+        id: `{i}`,
+        user: {
+          id: 1,
+          name: "bdougie",
+          user_email: "",
+          login: "bdougie",
+        },
+        name: `Repository Insight ${i + 1}`,
+        is_public: true,
+        is_favorite: false,
+        is_featured: false,
+        short_code: `my-insight-${i}`,
+        created_at: "2021-09-14T20:30:14.000Z",
+        updated_at: "2021-09-14T20:30:14.000Z",
+        repos: [],
+        members: [],
+      };
+    }),
+    type: "repo",
+  },
+};
+export const ContributorInsights: Story = {
+  args: {
+    title: "Contributor Insights",
+    username: "bdougie",
+    insights: new Array(5).fill("").map((_, i) => {
+      return {
+        id: `{i}`,
+        user: {
+          id: 1,
+          name: "bdougie",
+          user_email: "",
+          login: "bdougie",
+        },
+        name: `Contributor Insight ${i + 1}`,
+        is_public: true,
+        is_favorite: false,
+        created_at: "2021-09-14T20:30:14.000Z",
+        updated_at: "2021-09-14T20:30:14.000Z",
+      };
+    }),
+    type: "list",
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    title: "Repository Insights",
+    isLoading: true,
+  },
+};

--- a/components/shared/AppSidebar/InsightsPanel.tsx
+++ b/components/shared/AppSidebar/InsightsPanel.tsx
@@ -1,0 +1,55 @@
+import * as Collapsible from "@radix-ui/react-collapsible";
+import { FiChevronDown, FiChevronUp } from "react-icons/fi";
+import { Root, Thumb } from "@radix-ui/react-switch";
+import { useState } from "react";
+import ClientOnly from "components/atoms/ClientOnly/client-only";
+import SidebarMenuItem from "./sidebar-menu-item";
+
+interface InsightsPanelProps {
+  title: string;
+  username: string | null;
+  insights: DbUserList[] | DbUserInsight[];
+  type: "repo" | "list";
+  isLoading: boolean;
+}
+
+export const InsightsPanel = ({ title, username, insights, type, isLoading }: InsightsPanelProps) => {
+  const [open, setOpen] = useState(true);
+  return (
+    <Collapsible.Root open={open} onOpenChange={setOpen}>
+      <h3 className="uppercase text-gray-500 text-sm font-medium flex gap-1 items-center">
+        <span>{title}</span>
+        <Collapsible.Trigger asChild>
+          <Root
+            defaultChecked
+            checked={open}
+            onClick={() => {
+              setOpen(!open);
+            }}
+            name={`${title}-toggle`}
+          >
+            <Thumb>
+              <ClientOnly>
+                {open ? (
+                  <FiChevronDown className="w-4 h-4" title={`close ${title} panel`} />
+                ) : (
+                  <FiChevronUp className="w-4 h-4" title={`open ${title} panel`} />
+                )}
+              </ClientOnly>
+            </Thumb>
+          </Root>
+        </Collapsible.Trigger>
+      </h3>
+      <Collapsible.Content>
+        {isLoading ? null : (
+          <ul className="list-none w-full px-2 mt-1 [&_li]:border-l-2">
+            {insights.map((insight) => {
+              const url = type === "list" ? `/lists/${insight.id}` : `/pages/${username}/${insight.id}/dashboard`;
+              return <SidebarMenuItem key={insight.id} title={insight.name} href={url} type={type} />;
+            })}
+          </ul>
+        )}
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+};

--- a/components/shared/AppSidebar/InsightsPanel.tsx
+++ b/components/shared/AppSidebar/InsightsPanel.tsx
@@ -16,7 +16,7 @@ interface InsightsPanelProps {
 export const InsightsPanel = ({ title, username, insights, type, isLoading }: InsightsPanelProps) => {
   const [open, setOpen] = useState(true);
   return (
-    <Collapsible.Root open={open} onOpenChange={setOpen}>
+    <Collapsible.Root open={open} onOpenChange={setOpen} className="max-w-full overflow-x-hidden">
       <h3 className="uppercase text-gray-500 text-sm font-medium flex gap-1 items-center">
         <span>{title}</span>
         <Collapsible.Trigger asChild>

--- a/components/shared/AppSidebar/InsightsPanel.tsx
+++ b/components/shared/AppSidebar/InsightsPanel.tsx
@@ -17,18 +17,18 @@ export const InsightsPanel = ({ title, username, insights, type, isLoading }: In
   const [open, setOpen] = useState(true);
   return (
     <Collapsible.Root open={open} onOpenChange={setOpen} className="max-w-full overflow-x-hidden">
-      <h3 className="uppercase text-gray-500 text-sm font-medium flex gap-1 items-center">
-        <span>{title}</span>
-        <Collapsible.Trigger asChild>
-          <Root
-            defaultChecked
-            checked={open}
-            onClick={() => {
-              setOpen(!open);
-            }}
-            name={`${title}-toggle`}
-          >
-            <Thumb>
+      <Collapsible.Trigger asChild>
+        <Root
+          defaultChecked
+          checked={open}
+          onClick={() => {
+            setOpen(!open);
+          }}
+          name={`${title}-toggle`}
+        >
+          <Thumb>
+            <h3 className="uppercase text-gray-500 text-sm font-medium flex gap-1 items-center">
+              <span>{title}</span>
               <ClientOnly>
                 {open ? (
                   <FiChevronDown className="w-4 h-4" title={`close ${title} panel`} />
@@ -36,10 +36,10 @@ export const InsightsPanel = ({ title, username, insights, type, isLoading }: In
                   <FiChevronUp className="w-4 h-4" title={`open ${title} panel`} />
                 )}
               </ClientOnly>
-            </Thumb>
-          </Root>
-        </Collapsible.Trigger>
-      </h3>
+            </h3>
+          </Thumb>
+        </Root>
+      </Collapsible.Trigger>
       <Collapsible.Content>
         {isLoading ? null : (
           <ul className="list-none w-full px-2 mt-1 [&_li]:border-l-2">

--- a/components/shared/AppSidebar/InsightsPanel.tsx
+++ b/components/shared/AppSidebar/InsightsPanel.tsx
@@ -45,7 +45,7 @@ export const InsightsPanel = ({ title, username, insights, type, isLoading }: In
           <ul className="list-none w-full px-2 mt-1 [&_li]:border-l-2">
             {insights.map((insight) => {
               const url = type === "list" ? `/lists/${insight.id}` : `/pages/${username}/${insight.id}/dashboard`;
-              return <SidebarMenuItem key={insight.id} title={insight.name} href={url} type={type} />;
+              return <SidebarMenuItem key={insight.id} title={insight.name} url={url} type={type} />;
             })}
           </ul>
         )}

--- a/components/shared/AppSidebar/sidebar-menu-item.stories.tsx
+++ b/components/shared/AppSidebar/sidebar-menu-item.stories.tsx
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof SidebarMenuItem>;
 
 const baseProps: ComponentProps<typeof SidebarMenuItem> = {
   title: "My New List",
-  href: "/dashboard",
+  url: "/dashboard",
 };
 
 export const Default: Story = {
@@ -34,4 +34,8 @@ export const Repo: Story = {
 
 export const List: Story = {
   args: { ...baseProps, type: "list" },
+};
+
+export const IsActive: Story = {
+  args: { ...baseProps, type: "list", isActive: true },
 };

--- a/components/shared/AppSidebar/sidebar-menu-item.stories.tsx
+++ b/components/shared/AppSidebar/sidebar-menu-item.stories.tsx
@@ -35,7 +35,3 @@ export const Repo: Story = {
 export const List: Story = {
   args: { ...baseProps, type: "list" },
 };
-
-export const Active: Story = {
-  args: { ...baseProps, isActive: true, type: "list" },
-};

--- a/components/shared/AppSidebar/sidebar-menu-item.tsx
+++ b/components/shared/AppSidebar/sidebar-menu-item.tsx
@@ -2,30 +2,28 @@ import Link from "next/link";
 import React from "react";
 import { UsersIcon } from "@heroicons/react/24/solid";
 import { ChartBarSquareIcon } from "@heroicons/react/24/outline";
-import clsx from "clsx";
 
 interface MenuItemProps {
   title: string;
   icon?: React.ReactNode;
   type?: "repo" | "list";
   href: string;
-  isActive?: boolean;
 }
-const SidebarMenuItem = ({ title, icon, type, href, isActive }: MenuItemProps) => {
+const SidebarMenuItem = ({ title, icon, type, href }: MenuItemProps) => {
   const getIcon = (type: "repo" | "list") => {
     switch (type) {
       case "list":
-        return <UsersIcon className={clsx("w-5 h-5 text-slate-400", isActive && "text-slate-700")} />;
+        return <UsersIcon className="w-5 h-5 text-slate-400" />;
       case "repo":
-        return <ChartBarSquareIcon className={clsx("w-5 h-5 text-slate-400", isActive && "text-slate-700")} />;
+        return <ChartBarSquareIcon className="w-5 h-5 text-slate-400" />;
     }
   };
 
   return (
-    <li className={clsx("py-2 px-3", isActive ? "bg-slate-100" : "")}>
+    <li className="py-2 px-3 whitespace-nowrap overflow-hidden overflow-ellipsis">
       <Link href={href} className=" flex gap-2 items-center">
         {type && !icon ? getIcon(type) : icon}
-        <span className={clsx("text-slate-700 font-medium", isActive && "text-slate-800")}>{title}</span>
+        <span>{title}</span>
       </Link>
     </li>
   );

--- a/components/shared/AppSidebar/sidebar-menu-item.tsx
+++ b/components/shared/AppSidebar/sidebar-menu-item.tsx
@@ -7,9 +7,10 @@ interface MenuItemProps {
   title: string;
   icon?: React.ReactNode;
   type?: "repo" | "list";
-  href: string;
+  url: string;
+  isActive?: boolean;
 }
-const SidebarMenuItem = ({ title, icon, type, href }: MenuItemProps) => {
+const SidebarMenuItem = ({ title, icon, type, url: href }: MenuItemProps) => {
   const getIcon = (type: "repo" | "list") => {
     switch (type) {
       case "list":

--- a/components/shared/AppSidebar/sidebar-menu-item.tsx
+++ b/components/shared/AppSidebar/sidebar-menu-item.tsx
@@ -22,7 +22,7 @@ const SidebarMenuItem = ({ title, icon, type, href, isActive }: MenuItemProps) =
   };
 
   return (
-    <li className={clsx("list-none py-2 px-3 rounded-md", isActive ? "bg-slate-100" : "")}>
+    <li className={clsx("py-2 px-3", isActive ? "bg-slate-100" : "")}>
       <Link href={href} className=" flex gap-2 items-center">
         {type && !icon ? getIcon(type) : icon}
         <span className={clsx("text-slate-700 font-medium", isActive && "text-slate-800")}>{title}</span>

--- a/components/shared/AppSidebar/sidebar-menu-item.tsx
+++ b/components/shared/AppSidebar/sidebar-menu-item.tsx
@@ -20,10 +20,10 @@ const SidebarMenuItem = ({ title, icon, type, href }: MenuItemProps) => {
   };
 
   return (
-    <li className="py-2 px-3 whitespace-nowrap overflow-hidden overflow-ellipsis">
-      <Link href={href} className=" flex gap-2 items-center">
+    <li className="py-2 px-3">
+      <Link title={title} href={href} className="grid grid-cols-[1.25rem,1fr] gap-2 items-center">
         {type && !icon ? getIcon(type) : icon}
-        <span>{title}</span>
+        <span className="whitespace-nowrap overflow-hidden overflow-ellipsis">{title}</span>
       </Link>
     </li>
   );

--- a/lib/hooks/api/useGetWorkspaceRepositories.ts
+++ b/lib/hooks/api/useGetWorkspaceRepositories.ts
@@ -1,0 +1,18 @@
+import useSWR, { Fetcher, useSWRConfig } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
+
+export const useGetWorkspaceRepositories = (workspaceId: string) => {
+  const { mutate } = useSWRConfig();
+  const endpoint = `workspaces/${workspaceId}/repos`;
+
+  const { data, error, isLoading } = useSWR<any[], Error>(endpoint, publicApiFetcher as Fetcher<any[], Error>);
+
+  return {
+    data,
+    error,
+    revalidate() {
+      mutate(endpoint);
+    },
+    isLoading,
+  };
+};

--- a/lib/hooks/api/useGetWorkspaceRepositories.ts
+++ b/lib/hooks/api/useGetWorkspaceRepositories.ts
@@ -1,4 +1,4 @@
-import useSWR, { Fetcher, useSWRConfig } from "swr";
+import useSWR, { Fetcher } from "swr";
 import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 type DbWorkspaceRepository = {
@@ -13,10 +13,9 @@ type DbWorkspaceRepository = {
 };
 
 export const useGetWorkspaceRepositories = (workspaceId: string) => {
-  const { mutate } = useSWRConfig();
   const endpoint = `workspaces/${workspaceId}/repos`;
 
-  const { data, error, isLoading } = useSWR<PagedData<DbWorkspaceRepository>, Error>(
+  const { data, error, isLoading, mutate } = useSWR<PagedData<DbWorkspaceRepository>, Error>(
     endpoint,
     publicApiFetcher as Fetcher<PagedData<DbWorkspaceRepository>, Error>
   );
@@ -24,9 +23,7 @@ export const useGetWorkspaceRepositories = (workspaceId: string) => {
   return {
     data,
     error,
-    revalidate() {
-      mutate(endpoint);
-    },
+    mutate,
     isLoading,
   };
 };

--- a/lib/hooks/api/useGetWorkspaceRepositories.ts
+++ b/lib/hooks/api/useGetWorkspaceRepositories.ts
@@ -1,11 +1,25 @@
 import useSWR, { Fetcher, useSWRConfig } from "swr";
 import publicApiFetcher from "lib/utils/public-api-fetcher";
 
+type DbWorkspaceRepository = {
+  id: string;
+  repo_id: number;
+  workspace_id: string;
+  repo: {
+    id: number;
+    name: string;
+    full_name: string;
+  };
+};
+
 export const useGetWorkspaceRepositories = (workspaceId: string) => {
   const { mutate } = useSWRConfig();
   const endpoint = `workspaces/${workspaceId}/repos`;
 
-  const { data, error, isLoading } = useSWR<any[], Error>(endpoint, publicApiFetcher as Fetcher<any[], Error>);
+  const { data, error, isLoading } = useSWR<PagedData<DbWorkspaceRepository>, Error>(
+    endpoint,
+    publicApiFetcher as Fetcher<PagedData<DbWorkspaceRepository>, Error>
+  );
 
   return {
     data,

--- a/lib/hooks/useSearchRepos.ts
+++ b/lib/hooks/useSearchRepos.ts
@@ -1,71 +1,27 @@
+import useSWR, { Fetcher } from "swr";
+import githubApiFetcher from "lib/utils/github-api-fetcher";
+
 const baseUrl = "https://api.github.com/search/repositories";
-const useSearchRepos = (searchTerm: string | undefined, providerToken?: string | null | undefined, limit = 100) => {
+export const useSearchRepos = (
+  searchTerm: string | undefined,
+  providerToken?: string | null | undefined,
+  limit = 100
+) => {
+  const query = new URLSearchParams();
+  query.set("q", searchTerm ?? "");
+  query.set("per_page", `${limit}`);
+
+  const endpointString = `search/repositories?${query}`;
+
+  const { data, error, mutate } = useSWR<{ items: GhRepo[] }, Error>(
+    !searchTerm ? null : endpointString,
+    githubApiFetcher as Fetcher<{ items: GhRepo[] }, Error>
+  );
+
   return {
-    data: [
-      {
-        id: 688352,
-        name: "jmeter",
-        full_name: "apache/jmeter",
-        owner: {
-          login: "apache",
-        },
-      },
-      {
-        id: 434708679,
-        name: "test2",
-        full_name: "vitest-dev/vitest",
-        owner: {
-          login: "vitest-dev",
-        },
-      },
-    ],
-    isLoading: false,
-    isError: false,
+    data: data,
+    isLoading: !error && !data,
+    isError: !!error,
+    mutate,
   };
-  // try {
-  //   const query = new URLSearchParams({
-  //     q: searchTerm,
-  //     per_page: `${limit}`,
-  //   });
-  //   const res = await fetch(`${baseUrl}${query}`, {
-  //     ...(providerToken
-  //       ? {
-  //         headers: {
-  //           Authorization: `Bearer ${providerToken}`,
-  //         },
-  //       }
-  //       : {}),
-  //   });
-
-  //   if (res.status === 200) {
-  //     const data = (await res.json()).items as GhRepo[];
-  //     return { data, isLoading: false, isError: false };
-  //   } else {
-  //     // TODO
-  //     return { isError: true, isLoading: false, data: null };
-  //   }
-
-  //   // } else if (res.status === 403) {
-  //   //   // Use our API as a fallback
-  //   //   const fallbackResponse = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/repos/search`);
-
-  //   //   if (fallbackResponse.status === 200) {
-  //   //     const data = ((await fallbackResponse.json()).data as DbUser[]).map((user) => ({
-  //   //       id: user.id,
-  //   //       login: user.login,
-  //   //       full_name: user.name,
-  //   //       updated_at: user.updated_at,
-  //   //     })) as unknown as GhUser[];
-  //   //     return { data };
-  //   //   } else {
-  //   //     return false;
-  //   //   }
-  //   // } else {
-  //   //   return false;
-  //   // }
-  // } catch (e) {
-  //   return { isError: true, isLoading: false, data: null };
-  // }
 };
-
-export { useSearchRepos };

--- a/lib/hooks/useSearchRepos.ts
+++ b/lib/hooks/useSearchRepos.ts
@@ -19,7 +19,7 @@ export const useSearchRepos = (
   );
 
   return {
-    data: data,
+    data: data?.items.map((item) => item.full_name) ?? [],
     isLoading: !error && !data,
     isError: !!error,
     mutate,

--- a/lib/hooks/useSearchRepos.ts
+++ b/lib/hooks/useSearchRepos.ts
@@ -1,0 +1,71 @@
+const baseUrl = "https://api.github.com/search/repositories";
+const useSearchRepos = (searchTerm: string, providerToken?: string | null | undefined, limit = 100) => {
+  return {
+    data: [
+      {
+        id: 688352,
+        name: "jmeter",
+        full_name: "apache/jmeter",
+        owner: {
+          login: "apache",
+        },
+      },
+      {
+        id: 434708679,
+        name: "test2",
+        full_name: "vitest-dev/vitest",
+        owner: {
+          login: "vitest-dev",
+        },
+      },
+    ],
+    isLoading: false,
+    isError: false,
+  };
+  // try {
+  //   const query = new URLSearchParams({
+  //     q: searchTerm,
+  //     per_page: `${limit}`,
+  //   });
+  //   const res = await fetch(`${baseUrl}${query}`, {
+  //     ...(providerToken
+  //       ? {
+  //         headers: {
+  //           Authorization: `Bearer ${providerToken}`,
+  //         },
+  //       }
+  //       : {}),
+  //   });
+
+  //   if (res.status === 200) {
+  //     const data = (await res.json()).items as GhRepo[];
+  //     return { data, isLoading: false, isError: false };
+  //   } else {
+  //     // TODO
+  //     return { isError: true, isLoading: false, data: null };
+  //   }
+
+  //   // } else if (res.status === 403) {
+  //   //   // Use our API as a fallback
+  //   //   const fallbackResponse = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/repos/search`);
+
+  //   //   if (fallbackResponse.status === 200) {
+  //   //     const data = ((await fallbackResponse.json()).data as DbUser[]).map((user) => ({
+  //   //       id: user.id,
+  //   //       login: user.login,
+  //   //       full_name: user.name,
+  //   //       updated_at: user.updated_at,
+  //   //     })) as unknown as GhUser[];
+  //   //     return { data };
+  //   //   } else {
+  //   //     return false;
+  //   //   }
+  //   // } else {
+  //   //   return false;
+  //   // }
+  // } catch (e) {
+  //   return { isError: true, isLoading: false, data: null };
+  // }
+};
+
+export { useSearchRepos };

--- a/lib/hooks/useSearchRepos.ts
+++ b/lib/hooks/useSearchRepos.ts
@@ -1,5 +1,5 @@
 const baseUrl = "https://api.github.com/search/repositories";
-const useSearchRepos = (searchTerm: string, providerToken?: string | null | undefined, limit = 100) => {
+const useSearchRepos = (searchTerm: string | undefined, providerToken?: string | null | undefined, limit = 100) => {
   return {
     data: [
       {

--- a/lib/utils/github-api-fetcher.ts
+++ b/lib/utils/github-api-fetcher.ts
@@ -5,12 +5,12 @@ const baseUrl = "https://api.github.com";
 
 const githubApiFetcher: Fetcher = async (apiUrl: string) => {
   const sessionResponse = await supabase.auth.getSession();
-  const sessionToken = sessionResponse?.data.session?.access_token;
+  const sessionToken = sessionResponse?.data.session?.provider_token;
 
   const res = await fetch(`${baseUrl}/${apiUrl}`, {
     headers: {
       accept: "application/json",
-      // Authorization: `Bearer ${sessionToken}`,
+      Authorization: `Bearer ${sessionToken}`,
     },
   });
 

--- a/lib/utils/github-api-fetcher.ts
+++ b/lib/utils/github-api-fetcher.ts
@@ -10,7 +10,7 @@ const githubApiFetcher: Fetcher = async (apiUrl: string) => {
   const res = await fetch(`${baseUrl}/${apiUrl}`, {
     headers: {
       accept: "application/json",
-      Authorization: `Bearer ${sessionToken}`,
+      // Authorization: `Bearer ${sessionToken}`,
     },
   });
 

--- a/lib/utils/github-api-fetcher.ts
+++ b/lib/utils/github-api-fetcher.ts
@@ -1,0 +1,31 @@
+import { Fetcher } from "swr";
+import { supabase } from "./supabase";
+
+const baseUrl = "https://api.github.com";
+
+const githubApiFetcher: Fetcher = async (apiUrl: string) => {
+  const sessionResponse = await supabase.auth.getSession();
+  const sessionToken = sessionResponse?.data.session?.access_token;
+
+  const res = await fetch(`${baseUrl}/${apiUrl}`, {
+    headers: {
+      accept: "application/json",
+      // Authorization: `Bearer ${sessionToken}`,
+    },
+  });
+
+  if (!res.ok) {
+    const error = new Error("HttpError");
+
+    error.message = `${res.status} ${res.statusText}`;
+    error.stack = JSON.stringify(await res.json());
+    // eslint-disable-next-line no-console
+    console.error(error);
+
+    throw error;
+  }
+
+  return res.json();
+};
+
+export default githubApiFetcher;

--- a/lib/utils/workspace-utils.ts
+++ b/lib/utils/workspace-utils.ts
@@ -13,7 +13,6 @@ export async function createWorkspace({
   sessionToken: string;
   repos: { full_name: string }[];
 }) {
-  // TODO: check if the workspace ID already exists in case the repos part doesn't work
   const { data: workspace, error: workspaceError } = await fetchApiData<Workspace>({
     path: "workspaces",
     method: "POST",

--- a/lib/utils/workspace-utils.ts
+++ b/lib/utils/workspace-utils.ts
@@ -1,0 +1,110 @@
+import { fetchApiData } from "helpers/fetchApiData";
+
+export async function createWorkspace({
+  name,
+  description = "",
+  members = [],
+  sessionToken,
+  repos = [],
+}: {
+  name: string;
+  description?: string;
+  members?: any[];
+  sessionToken: string;
+  repos: { full_name: string }[];
+}) {
+  // TODO: check if the workspace ID already exists in case the repos part doesn't work
+  const { data: workspace, error: workspaceError } = await fetchApiData<Workspace>({
+    path: "workspaces",
+    method: "POST",
+    body: { name, description, members },
+    bearerToken: sessionToken,
+    pathValidator: () => true,
+  });
+
+  if (workspace) {
+    const { data: repoData, error: reposError } = await fetchApiData<any[]>({
+      path: `workspaces/${workspace.id}/repos`,
+      method: "POST",
+      body: { repos },
+      bearerToken: sessionToken,
+      pathValidator: () => true,
+    });
+
+    if (workspaceError || reposError) {
+      return { data: null, error: workspaceError ?? reposError };
+    }
+
+    return { data: { workspace, repos: repoData }, error: null };
+  } else {
+    return { data: null, error: workspaceError };
+  }
+}
+
+export async function saveWorkspace({
+  workspaceId,
+  name,
+  description = "",
+  sessionToken,
+  repos,
+}: {
+  workspaceId: string;
+  name: string;
+  description?: string;
+  sessionToken: string;
+  repos: { full_name: string }[];
+}) {
+  const updateWorkspace = await fetchApiData<Workspace>({
+    path: `workspaces/${workspaceId}`,
+    method: "PATCH",
+    body: { name, description },
+    bearerToken: sessionToken,
+    pathValidator: () => true,
+  });
+
+  const updateWorkspaceRepos = await fetchApiData<any[]>({
+    path: `workspaces/${workspaceId}/repos`,
+    method: "POST",
+    body: { repos },
+    bearerToken: sessionToken,
+    pathValidator: () => true,
+  });
+
+  const [{ data, error }, { data: repoData, error: reposError }] = await Promise.all([
+    updateWorkspace,
+    updateWorkspaceRepos,
+  ]);
+
+  return { data: { workspace: data, repos: repoData }, error };
+}
+
+export async function deleteTrackedRepos({
+  workspaceId,
+  sessionToken,
+  repos,
+}: {
+  workspaceId: string;
+  sessionToken: string;
+  repos: { full_name: string }[];
+}) {
+  const { data, error } = await fetchApiData<any[]>({
+    path: `workspaces/${workspaceId}/repos`,
+    method: "DELETE",
+    body: { repos },
+    bearerToken: sessionToken,
+    pathValidator: () => true,
+  });
+
+  return { data, error };
+}
+
+export async function deleteWorkspace({ workspaceId, sessionToken }: { workspaceId: string; sessionToken: string }) {
+  const { data, error } = await fetchApiData<Workspace>({
+    path: `workspaces/${workspaceId}`,
+    method: "DELETE",
+    bearerToken: sessionToken,
+    pathValidator: () => true,
+  });
+
+  return { data, error };
+}

--- a/next-types.d.ts
+++ b/next-types.d.ts
@@ -277,6 +277,14 @@ interface GhUser {
   readonly repos_url: string;
 }
 
+interface GhRepo {
+  id: number;
+  name: string;
+  full_name: string;
+  private: boolean;
+  owner: GhUser;
+}
+
 interface GhPRInfoResponse {
   readonly head: { repo: { name: string; full_name: string }; user: { login: string; full_name: string } };
   readonly title: string;

--- a/pages/workspaces/[workspaceId]/settings.tsx
+++ b/pages/workspaces/[workspaceId]/settings.tsx
@@ -54,9 +54,10 @@ const WorkspaceSettings = ({ workspace }: WorkspaceSettingsProps) => {
   const [trackedRepos, setTrackedRepos] = useState<string[]>([]);
   const [trackedReposPendingDeletion, setTrackedReposPendingDeletion] = useState<string[]>([]);
 
+  // TODO: Make this a map or object to be more efficient
   // initial tracked repos + newly selected tracked repos that are not pending deletion
-  const pendingTrackedRepos = trackedRepos.concat(
-    initialTrackedRepos.filter((repo) => !trackedReposPendingDeletion.includes(repo))
+  const pendingTrackedRepos = Array.from(
+    new Set(trackedRepos.concat(initialTrackedRepos.filter((repo) => !trackedReposPendingDeletion.includes(repo))))
   );
 
   const TrackedReposModal = dynamic(() => import("components/Workspaces/TrackedReposModal"), {

--- a/pages/workspaces/[workspaceId]/settings.tsx
+++ b/pages/workspaces/[workspaceId]/settings.tsx
@@ -50,7 +50,7 @@ const WorkspaceSettings = ({ workspace }: WorkspaceSettingsProps) => {
   const [workspaceName, setWorkspaceName] = useState(workspace.name);
   const { setWorkspaces, workspaces } = store(({ setWorkspaces, workspaces }) => ({ setWorkspaces, workspaces }));
   const [trackedReposModalOpen, setTrackedReposModalOpen] = useState(false);
-  const { data, error, revalidate: revalidateRepos, isLoading } = useGetWorkspaceRepositories(workspace.id);
+  const { data, error, mutate: mutateTrackedRepos, isLoading } = useGetWorkspaceRepositories(workspace.id);
   const initialTrackedRepos: string[] = data?.data?.map(({ repo }) => repo.full_name) ?? [];
   const [trackedRepos, setTrackedRepos] = useState<string[]>(initialTrackedRepos);
   const [trackedReposPendingDeletion, setTrackedReposPendingDeletion] = useState<string[]>([]);
@@ -89,9 +89,10 @@ const WorkspaceSettings = ({ workspace }: WorkspaceSettingsProps) => {
     if (error || reposDeleteError) {
       toast({ description: `Workspace update failed`, variant: "danger" });
     } else {
-      revalidateRepos();
       setWorkspaceName(name);
       data.workspace && setWorkspaces([...workspaces.filter((w) => w.id !== workspace.id), data.workspace]);
+      await mutateTrackedRepos();
+
       toast({ description: `Workspace updated successfully`, variant: "success" });
     }
   };

--- a/pages/workspaces/[workspaceId]/settings.tsx
+++ b/pages/workspaces/[workspaceId]/settings.tsx
@@ -12,6 +12,8 @@ import { useToast } from "lib/hooks/useToast";
 import Title from "components/atoms/Typography/title";
 import Text from "components/atoms/Typography/text";
 import store from "lib/store";
+import { TrackedReposTable } from "components/Workspaces/TrackedReposTable";
+import { useGetWorkspaceRepositories } from "lib/hooks/api/useGetWorkspaceRepositories";
 
 const DeleteWorkspaceModal = dynamic(() => import("components/Workspaces/DeleteWorkspaceModal"), { ssr: false });
 
@@ -20,13 +22,15 @@ async function saveWorkspace({
   name,
   description = "",
   sessionToken,
+  repos,
 }: {
   workspaceId: string;
   name: string;
   description?: string;
   sessionToken: string;
+  repos: { full_name: string }[];
 }) {
-  const { data, error } = await fetchApiData<Workspace>({
+  const updateWorkspace = await fetchApiData<Workspace>({
     path: `workspaces/${workspaceId}`,
     method: "PATCH",
     body: { name, description },
@@ -34,7 +38,20 @@ async function saveWorkspace({
     pathValidator: () => true,
   });
 
-  return { data, error };
+  const updateWorkspaceRepos = await fetchApiData<any[]>({
+    path: `workspaces/${workspaceId}/repos`,
+    method: "POST",
+    body: { repos },
+    bearerToken: sessionToken,
+    pathValidator: () => true,
+  });
+
+  const [{ data, error }, { data: repoData, error: reposError }] = await Promise.all([
+    updateWorkspace,
+    updateWorkspaceRepos,
+  ]);
+
+  return { data: { workspace: data, repos: repoData }, error };
 }
 
 const deleteWorkspace = async ({ workspaceId, sessionToken }: { workspaceId: string; sessionToken: string }) => {
@@ -79,87 +96,126 @@ const WorkspaceSettings = ({ workspace }: WorkspaceSettingsProps) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [workspaceName, setWorkspaceName] = useState(workspace.name);
   const { setWorkspaces, workspaces } = store(({ setWorkspaces, workspaces }) => ({ setWorkspaces, workspaces }));
+  const [trackedReposModalOpen, setTrackedReposModalOpen] = useState(false);
+  const { data, error, revalidate: revalidateRepos, isLoading } = useGetWorkspaceRepositories(workspace.id);
+  const initialTrackedRepos: string[] = data?.data.map(({ repo }) => repo.full_name) ?? [];
+  const [trackedRepos, setTrackedRepos] = useState<string[]>(initialTrackedRepos);
+
+  const TrackedReposModal = dynamic(() => import("components/Workspaces/TrackedReposModal"), {
+    ssr: false,
+  });
 
   return (
     <WorkspaceLayout>
-      <h1 className="border-b bottom pb-4">Workspace Settings</h1>
-      <form
-        className="flex flex-col pt-6 gap-6"
-        onSubmit={async (event) => {
-          event.preventDefault();
-          const form = event.target as HTMLFormElement;
-          const formData = new FormData(form);
-          const name = formData.get("name") as string;
-          const description = formData.get("description") as string;
-          const { data, error } = await saveWorkspace({
-            workspaceId: workspace.id,
-            name,
-            description,
-            sessionToken: sessionToken!,
-          });
+      {" "}
+      <div className="grid gap-6">
+        <div>
+          <h1 className="border-b bottom pb-4">Workspace Settings</h1>
+          <form
+            className="flex flex-col pt-6 gap-6"
+            onSubmit={async (event) => {
+              event.preventDefault();
+              const form = event.target as HTMLFormElement;
+              const formData = new FormData(form);
+              const name = formData.get("name") as string;
+              const description = formData.get("description") as string;
+              const { data, error } = await saveWorkspace({
+                workspaceId: workspace.id,
+                name,
+                description,
+                sessionToken: sessionToken!,
+                repos: trackedRepos.map((repo) => ({ full_name: repo })),
+              });
 
-          if (error) {
-            toast({ description: `Workspace update failed`, variant: "danger" });
-          } else {
-            setWorkspaceName(name);
-            data && setWorkspaces([...workspaces.filter((w) => w.id !== workspace.id), data]);
-            toast({ description: `Workspace updated successfully`, variant: "success" });
-          }
-        }}
-      >
-        <TextInput
-          name="name"
-          label="Workspace Name"
-          defaultValue={workspace.name}
-          placeholder="Workspace name"
-          className="w-full md:w-max"
-          required
-        />
-        <TextInput
-          name="description"
-          label="Workspace Description"
-          defaultValue={workspace.description}
-          placeholder="Workspace description"
-          className="w-full md:w-3/4 max-w-lg"
-        />
-        <div className="bg-white sticky-bottom fixed bottom-0 right-0 self-end m-6">
-          <Button variant="primary" className="flex gap-2.5 items-center cursor-pointer w-min mt-2 sm:mt-0 self-end">
-            Update Workspace
-          </Button>
+              if (error) {
+                toast({ description: `Workspace update failed`, variant: "danger" });
+              } else {
+                setWorkspaceName(name);
+                data.workspace && setWorkspaces([...workspaces.filter((w) => w.id !== workspace.id), data.workspace]);
+                toast({ description: `Workspace updated successfully`, variant: "success" });
+                revalidateRepos();
+              }
+            }}
+          >
+            <TextInput
+              name="name"
+              label="Workspace Name"
+              defaultValue={workspace.name}
+              placeholder="Workspace name"
+              className="w-full md:w-max"
+              required
+            />
+            <TextInput
+              name="description"
+              label="Workspace Description"
+              defaultValue={workspace.description}
+              placeholder="Workspace description"
+              className="w-full md:w-3/4 max-w-lg"
+            />
+            <div className="bg-white sticky-bottom fixed bottom-0 right-0 self-end m-6">
+              <Button
+                variant="primary"
+                className="flex gap-2.5 items-center cursor-pointer w-min mt-2 sm:mt-0 self-end"
+              >
+                Update Workspace
+              </Button>
+            </div>
+          </form>
         </div>
-      </form>
-      <div className="flex flex-col gap-4 py-6">
-        <Title className="!text-1xl !leading-none py-6" level={4}>
-          Danger Zone
-        </Title>
-
-        <div className="flex flex-col p-6 rounded-2xl bg-light-slate-4">
-          <Title className="!text-1xl !leading-none !border-light-slate-8 border-b pb-4" level={4}>
-            Delete Workspace
+        <TrackedReposTable
+          repositories={trackedRepos}
+          onAddRepos={() => {
+            setTrackedReposModalOpen(true);
+          }}
+          onRemoveTrackedRepo={() => {}}
+        />
+        <div className="flex flex-col gap-4">
+          <Title className="!text-1xl !leading-none py-6" level={4}>
+            Danger Zone
           </Title>
-          <Text className="my-4">Once you delete a workspace, you&#39;re past the point of no return.</Text>
 
-          <div>
-            <Button onClick={() => setIsDeleteModalOpen(true)} variant="destructive">
-              Delete workspace
-            </Button>
+          <div className="flex flex-col p-6 rounded-2xl bg-light-slate-4">
+            <Title className="!text-1xl !leading-none !border-light-slate-8 border-b pb-4" level={4}>
+              Delete Workspace
+            </Title>
+            <Text className="my-4">Once you delete a workspace, you&#39;re past the point of no return.</Text>
+
+            <div>
+              <Button onClick={() => setIsDeleteModalOpen(true)} variant="destructive">
+                Delete workspace
+              </Button>
+            </div>
           </div>
         </div>
+        <TrackedReposModal
+          isOpen={trackedReposModalOpen}
+          onClose={() => {
+            setTrackedReposModalOpen(false);
+          }}
+          onAddToTrackingList={(repos: string[]) => {
+            setTrackedReposModalOpen(false);
+            // TODO: Make this a map or object to be more efficient
+            setTrackedRepos((trackedRepos) => [...trackedRepos, ...repos]);
+          }}
+          onCancel={() => {
+            setTrackedReposModalOpen(false);
+          }}
+        />
+        <DeleteWorkspaceModal
+          isOpen={isDeleteModalOpen}
+          onClose={() => setIsDeleteModalOpen(false)}
+          workspaceName={workspaceName}
+          onDelete={async () => {
+            const { error } = await deleteWorkspace({ workspaceId: workspace.id, sessionToken: sessionToken! });
+            if (error) {
+              toast({ description: `Workspace delete failed`, variant: "danger" });
+            } else {
+              toast({ description: `Workspace deleted successfully`, variant: "success" });
+              router.push("/workspaces/new");
+            }
+          }}
+        />
       </div>
-      <DeleteWorkspaceModal
-        isOpen={isDeleteModalOpen}
-        onClose={() => setIsDeleteModalOpen(false)}
-        workspaceName={workspaceName}
-        onDelete={async () => {
-          const { error } = await deleteWorkspace({ workspaceId: workspace.id, sessionToken: sessionToken! });
-          if (error) {
-            toast({ description: `Workspace delete failed`, variant: "danger" });
-          } else {
-            toast({ description: `Workspace deleted successfully`, variant: "success" });
-            router.push("/workspaces/new");
-          }
-        }}
-      />
     </WorkspaceLayout>
   );
 };

--- a/pages/workspaces/[workspaceId]/settings.tsx
+++ b/pages/workspaces/[workspaceId]/settings.tsx
@@ -14,76 +14,9 @@ import Text from "components/atoms/Typography/text";
 import store from "lib/store";
 import { TrackedReposTable } from "components/Workspaces/TrackedReposTable";
 import { useGetWorkspaceRepositories } from "lib/hooks/api/useGetWorkspaceRepositories";
+import { deleteTrackedRepos, deleteWorkspace, saveWorkspace } from "lib/utils/workspace-utils";
 
 const DeleteWorkspaceModal = dynamic(() => import("components/Workspaces/DeleteWorkspaceModal"), { ssr: false });
-
-async function saveWorkspace({
-  workspaceId,
-  name,
-  description = "",
-  sessionToken,
-  repos,
-}: {
-  workspaceId: string;
-  name: string;
-  description?: string;
-  sessionToken: string;
-  repos: { full_name: string }[];
-}) {
-  const updateWorkspace = await fetchApiData<Workspace>({
-    path: `workspaces/${workspaceId}`,
-    method: "PATCH",
-    body: { name, description },
-    bearerToken: sessionToken,
-    pathValidator: () => true,
-  });
-
-  const updateWorkspaceRepos = await fetchApiData<any[]>({
-    path: `workspaces/${workspaceId}/repos`,
-    method: "POST",
-    body: { repos },
-    bearerToken: sessionToken,
-    pathValidator: () => true,
-  });
-
-  const [{ data, error }, { data: repoData, error: reposError }] = await Promise.all([
-    updateWorkspace,
-    updateWorkspaceRepos,
-  ]);
-
-  return { data: { workspace: data, repos: repoData }, error };
-}
-
-const deleteTrackedRepos = async ({
-  workspaceId,
-  sessionToken,
-  repos,
-}: {
-  workspaceId: string;
-  sessionToken: string;
-  repos: { full_name: string }[];
-}) => {
-  const { data, error } = await fetchApiData<any[]>({
-    path: `workspaces/${workspaceId}/repos`,
-    method: "DELETE",
-    body: { repos },
-    bearerToken: sessionToken,
-    pathValidator: () => true,
-  });
-
-  return { data, error };
-};
-
-const deleteWorkspace = async ({ workspaceId, sessionToken }: { workspaceId: string; sessionToken: string }) => {
-  const { data, error } = await fetchApiData<Workspace>({
-    path: `workspaces/${workspaceId}`,
-    method: "DELETE",
-    bearerToken: sessionToken,
-    pathValidator: () => true,
-  });
-
-  return { data, error };
-};
 
 interface WorkspaceSettingsProps {
   workspace: Workspace;

--- a/pages/workspaces/[workspaceId]/settings.tsx
+++ b/pages/workspaces/[workspaceId]/settings.tsx
@@ -129,6 +129,7 @@ const WorkspaceSettings = ({ workspace }: WorkspaceSettingsProps) => {
           </form>
         </div>
         <TrackedReposTable
+          isLoading={isLoading}
           repositories={trackedRepos}
           onAddRepos={() => {
             setTrackedReposModalOpen(true);

--- a/pages/workspaces/[workspaceId]/settings.tsx
+++ b/pages/workspaces/[workspaceId]/settings.tsx
@@ -80,13 +80,13 @@ const WorkspaceSettings = ({ workspace }: WorkspaceSettingsProps) => {
       name,
       description,
       sessionToken: sessionToken!,
-      repos: Array.from(trackedRepos).map((repo) => ({ full_name: repo })),
+      repos: Array.from(trackedRepos, (repo) => ({ full_name: repo })),
     });
 
     const workspaceRepoDeletes = await deleteTrackedRepos({
       workspaceId: workspace.id,
       sessionToken: sessionToken!,
-      repos: Array.from(trackedReposPendingDeletion).map((repo) => ({ full_name: repo })),
+      repos: Array.from(trackedReposPendingDeletion, (repo) => ({ full_name: repo })),
     });
 
     const [{ data, error }, { data: deletedRepos, error: reposDeleteError }] = await Promise.all([

--- a/pages/workspaces/[workspaceId]/settings.tsx
+++ b/pages/workspaces/[workspaceId]/settings.tsx
@@ -98,7 +98,7 @@ const WorkspaceSettings = ({ workspace }: WorkspaceSettingsProps) => {
   const { setWorkspaces, workspaces } = store(({ setWorkspaces, workspaces }) => ({ setWorkspaces, workspaces }));
   const [trackedReposModalOpen, setTrackedReposModalOpen] = useState(false);
   const { data, error, revalidate: revalidateRepos, isLoading } = useGetWorkspaceRepositories(workspace.id);
-  const initialTrackedRepos: string[] = data?.data.map(({ repo }) => repo.full_name) ?? [];
+  const initialTrackedRepos: string[] = data?.data?.map(({ repo }) => repo.full_name) ?? [];
   const [trackedRepos, setTrackedRepos] = useState<string[]>(initialTrackedRepos);
 
   const TrackedReposModal = dynamic(() => import("components/Workspaces/TrackedReposModal"), {

--- a/pages/workspaces/new.tsx
+++ b/pages/workspaces/new.tsx
@@ -4,52 +4,11 @@ import { ComponentProps, useState } from "react";
 import { WorkspaceLayout } from "components/Workspaces/WorkspaceLayout";
 import Button from "components/atoms/Button/button";
 import TextInput from "components/atoms/TextInput/text-input";
-import { fetchApiData } from "helpers/fetchApiData";
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
 import { useToast } from "lib/hooks/useToast";
 import store from "lib/store";
 import { TrackedReposTable } from "components/Workspaces/TrackedReposTable";
-
-async function createWorkspace({
-  name,
-  description = "",
-  members = [],
-  sessionToken,
-  repos = [],
-}: {
-  name: string;
-  description?: string;
-  members?: any[];
-  sessionToken: string;
-  repos: { full_name: string }[];
-}) {
-  // TODO: check if the workspace ID already exists in case the repos part doesn't work
-  const { data: workspace, error: workspaceError } = await fetchApiData<Workspace>({
-    path: "workspaces",
-    method: "POST",
-    body: { name, description, members },
-    bearerToken: sessionToken,
-    pathValidator: () => true,
-  });
-
-  if (workspace) {
-    const { data: repoData, error: reposError } = await fetchApiData<any[]>({
-      path: `workspaces/${workspace.id}/repos`,
-      method: "POST",
-      body: { repos },
-      bearerToken: sessionToken,
-      pathValidator: () => true,
-    });
-
-    if (workspaceError || reposError) {
-      return { data: null, error: workspaceError ?? reposError };
-    }
-
-    return { data: { workspace, repos: repoData }, error: null };
-  } else {
-    return { data: null, error: workspaceError };
-  }
-}
+import { createWorkspace } from "lib/utils/workspace-utils";
 
 const NewWorkspace = () => {
   const { sessionToken } = useSupabaseAuth();
@@ -65,10 +24,11 @@ const NewWorkspace = () => {
     const formData = new FormData(form);
     const name = formData.get("name") as string;
     const description = formData.get("description") as string;
-    // TODO: send members list
+
     const { data, error } = await createWorkspace({
       name,
       description,
+      // TODO: send members list
       members: [],
       sessionToken: sessionToken!,
       repos: trackedRepos.map((repo) => ({ full_name: repo })),

--- a/pages/workspaces/new.tsx
+++ b/pages/workspaces/new.tsx
@@ -118,7 +118,6 @@ const NewWorkspace = () => {
         onClose={() => {
           setTrackedReposModalOpen(false);
         }}
-        trackedReposCount={0}
         onAddToTrackingList={() => {}}
         onCancel={() => {}}
       />

--- a/pages/workspaces/new.tsx
+++ b/pages/workspaces/new.tsx
@@ -9,7 +9,6 @@ import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
 import { useToast } from "lib/hooks/useToast";
 import store from "lib/store";
 import { TrackedReposTable } from "components/Workspaces/TrackedReposTable";
-import { useSearchRepos } from "lib/hooks/useSearchRepos";
 
 async function createWorkspace({
   name,
@@ -38,15 +37,8 @@ const NewWorkspace = () => {
   const { toast } = useToast();
   const router = useRouter();
   const { setWorkspaces, workspaces } = store(({ setWorkspaces, workspaces }) => ({ setWorkspaces, workspaces }));
+  const trackedRepos: any[] = [];
   const [trackedReposModalOpen, setTrackedReposModalOpen] = useState(false);
-  const [searchedRepos, setSearchedRepos] = useState<GhRepo[]>([]);
-  const [searchTerm, setSearchTerm] = useState<string | undefined>();
-
-  const { data, isError, isLoading } = useSearchRepos(searchTerm, sessionToken);
-
-  function onSearchRepos(searchTerm?: string) {
-    setSearchTerm(searchTerm);
-  }
 
   function onAddOrgRepo() {
     alert("Add org repo");
@@ -114,7 +106,7 @@ const NewWorkspace = () => {
           </form>
         </div>
         <TrackedReposTable
-          repositories={searchedRepos}
+          repositories={trackedRepos}
           onAddRepos={() => {
             setTrackedReposModalOpen(true);
           }}
@@ -128,9 +120,6 @@ const NewWorkspace = () => {
         }}
         trackedReposCount={0}
         onAddToTrackingList={() => {}}
-        onSearchRepos={(searchTerm: string) => {
-          setSearchTerm(searchTerm);
-        }}
         onCancel={() => {}}
       />
     </WorkspaceLayout>

--- a/pages/workspaces/new.tsx
+++ b/pages/workspaces/new.tsx
@@ -89,7 +89,7 @@ const NewWorkspace = () => {
                 toast({ description: `Error creating new workspace. Please try again`, variant: "danger" });
               } else {
                 toast({ description: `Workspace created successfully`, variant: "success" });
-                data && setWorkspaces([...workspaces, data]);
+                data && setWorkspaces([...workspaces, data.workspace]);
                 router.push(`/workspaces/${data?.workspace.id}/settings`);
               }
             }}

--- a/pages/workspaces/new.tsx
+++ b/pages/workspaces/new.tsx
@@ -30,7 +30,7 @@ const NewWorkspace = () => {
       // TODO: send members list
       members: [],
       sessionToken: sessionToken!,
-      repos: Array.from(trackedRepos).map((repo) => ({ full_name: repo })),
+      repos: Array.from(trackedRepos, (repo) => ({ full_name: repo })),
     });
 
     if (error) {

--- a/pages/workspaces/new.tsx
+++ b/pages/workspaces/new.tsx
@@ -15,7 +15,7 @@ const NewWorkspace = () => {
   const { toast } = useToast();
   const router = useRouter();
   const [trackedReposModalOpen, setTrackedReposModalOpen] = useState(false);
-  const [trackedRepos, setTrackedRepos] = useState<string[]>([]);
+  const [trackedRepos, setTrackedRepos] = useState<Set<string>>(new Set());
 
   const onCreateWorkspace: ComponentProps<"form">["onSubmit"] = async (event) => {
     event.preventDefault();
@@ -30,7 +30,7 @@ const NewWorkspace = () => {
       // TODO: send members list
       members: [],
       sessionToken: sessionToken!,
-      repos: trackedRepos.map((repo) => ({ full_name: repo })),
+      repos: Array.from(trackedRepos).map((repo) => ({ full_name: repo })),
     });
 
     if (error) {
@@ -89,7 +89,12 @@ const NewWorkspace = () => {
               return;
             }
 
-            setTrackedRepos((repos) => repos.filter((r) => r !== repo));
+            setTrackedRepos((trackedRepos) => {
+              const updates = new Set([...trackedRepos]);
+              updates.delete(repo);
+
+              return updates;
+            });
           }}
         />
       </div>
@@ -98,10 +103,11 @@ const NewWorkspace = () => {
         onClose={() => {
           setTrackedReposModalOpen(false);
         }}
-        onAddToTrackingList={(repos: string[]) => {
+        onAddToTrackingList={(repos: Set<string>) => {
           setTrackedReposModalOpen(false);
-          // TODO: Make this a map or object to be more efficient
-          setTrackedRepos((trackedRepos) => [...trackedRepos, ...repos]);
+          setTrackedRepos((trackedRepos) => {
+            return new Set([...trackedRepos, ...repos]);
+          });
         }}
         onCancel={() => {
           setTrackedReposModalOpen(false);


### PR DESCRIPTION
## Description

This is under a feature flag atm. Only the OpenSauced team can see it. There is currently minimal workspace creation/edition in the app. This adds the ability to manage tracked repositories.

The search is finicky sometime when searching for a repository. I thought this was something I introduced, but appears to be happening elsewhere in the app as well, e.g. adding repositories in the new insights page, so that will get addressed in a separate issue.

Note that this PR is only for the search by repos flow. Another pull request will introduce search for repost by org (#2505).

![image](https://github.com/open-sauced/app/assets/833231/50c5d85c-0ef3-4a1d-b955-2d65656920a2)

There will probably be some additional polish to the whole epic for tracked repositories, but that will be small PRs coming after.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Relates #2437
Closes #2482


## Mobile & Desktop Screenshots/Recordings

![CleanShot 2024-01-23 at 23 32 14](https://github.com/open-sauced/app/assets/833231/16609611-8dd2-4e07-afc3-8016444ef6c5)

![CleanShot 2024-01-23 at 23 43 48](https://github.com/open-sauced/app/assets/833231/139a5068-f811-45b2-810f-f01e2539998a)

![CleanShot 2024-01-23 at 23 47 30](https://github.com/open-sauced/app/assets/833231/3c8db3bb-1d5e-4e01-bfa4-c55698e8d936)

![CleanShot 2024-01-23 at 23 46 56](https://github.com/open-sauced/app/assets/833231/6da5a66b-0c08-41b4-960d-bc4760415bc9)

https://github.com/open-sauced/app/assets/833231/786f3872-7691-4ccd-9453-0dae52674bf0

## TODOs

- [x] polishing of the feature
- [x] get useSWR caching issue sorted for tracked repos on the settings page. The first call should have repos in the settings page after creating a new workspace
- [x] width resizing of wizard when searching for repos and results load in the table
- [x] ~Get search component in search by repos step working properly. Results don't always load~ This appears to be an existing issue in the app.
- [x] Get search component in search by repos step working properly for clicking on a selected repo. Currently clicking closes the search, but does not add the selected repo. Probably missing an onClick
- [x] Fix Storybook stories and most likely merge them into one story for wizard steps.


For these, they're a separate issue raised here https://github.com/open-sauced/api/issues/511

- [ ] ~sometimes creating a repo fails because the endpoint for adding repos to the new workspace gives a 404. The workspace is created successfully, so it does exist. My guess is the endpoint 404s because maybe the database hasn't updated yet, so the repos endpoint 404s. A second attempt could be made as a "temporary" fix~
- [ ] ~sometimes I get 404s for the updating repos endpoint. Same for getting repos, e.g. 
https://beta.api.opensauced.pizza/v1/workspaces/9e0c76a8-9034-4670-94e8-f73b4a5c8679/repos~
- [ ] ~separate issue, but make the sidebar collapsible~

## Steps to QA

1. Ensure you're logged in
2. Navigate to https://deploy-preview-2502--oss-insights.netlify.app/workspaces/new
3. Fill in the required workspace info (name) and add some repositories to track.
4. Create the workspace and you'll be redirected to the workspace settings page.
5. Add or remove some tracked repos and update the workspace.
6. Notice the tracked repositories update. They might rearrange in order.


## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [x] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

We'll need to coordinate with @BekahHW for documentation updates around workspaces, list and insights.

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/3ohhweiVB36rAlqVCE/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
