### PR TITLE
fix: add missing skeleton loader for insights panel

### DIFF
--- a/components/shared/AppSidebar/InsightsPanel.tsx
+++ b/components/shared/AppSidebar/InsightsPanel.tsx
@@ -3,6 +3,7 @@ import { FiChevronDown, FiChevronUp } from "react-icons/fi";
 import { Root, Thumb } from "@radix-ui/react-switch";
 import { useState } from "react";
 import ClientOnly from "components/atoms/ClientOnly/client-only";
+import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
 import SidebarMenuItem from "./sidebar-menu-item";
 
 interface InsightsPanelProps {
@@ -12,6 +13,20 @@ interface InsightsPanelProps {
   type: "repo" | "list";
   isLoading: boolean;
 }
+
+const Loading = () => {
+  return (
+    <ul className="list-none w-full px-2 mt-1 [&_li]:border-l-2">
+      {new Array(5).fill(0).map((_, i) => {
+        return (
+          <li key={i} className="p-2">
+            <SkeletonWrapper height={20} />
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
 
 export const InsightsPanel = ({ title, username, insights, type, isLoading }: InsightsPanelProps) => {
   const [open, setOpen] = useState(true);
@@ -41,7 +56,9 @@ export const InsightsPanel = ({ title, username, insights, type, isLoading }: In
         </Root>
       </Collapsible.Trigger>
       <Collapsible.Content>
-        {isLoading ? null : (
+        {isLoading ? (
+          <Loading />
+        ) : (
           <ul className="list-none w-full px-2 mt-1 [&_li]:border-l-2">
             {insights.map((insight) => {
               const url = type === "list" ? `/lists/${insight.id}` : `/pages/${username}/${insight.id}/dashboard`;


### PR DESCRIPTION
## Description

Adds a skeleton loader for the insights panel component used in the application sidebar.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #2525

## Mobile & Desktop Screenshots/Recordings

https://github.com/open-sauced/app/assets/833231/6a8e09f6-44e6-47ef-8056-4e6c822e3dee

## Steps to QA

N/A. You can [test it out in Storybook](https://deploy-preview-2524--design-insights.netlify.app/?path=/story/components-workspaces-insightspanel--loading).


## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [x] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/2gLxx75OmfCaNu2yI8/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
