### PR TITLE
feat: Adds missing data points on "most-active-contributors" API hook

### DIFF
--- a/next-types.d.ts
+++ b/next-types.d.ts
@@ -368,7 +368,13 @@ interface PagedData<T> {
 interface DbListContributorStat {
   login: string;
   commits: number;
-  prsCreated: number;
+  prs_created: number;
+  issues_created: number;
+  commit_comments: number;
+  issue_comments: number;
+  pr_review_comments: number;
+  comments: number;
+  total_contributions: number;
 }
 
 interface DbProjectContributions {


### PR DESCRIPTION
## Description

Small followup to https://github.com/open-sauced/app/issues/2515 which adds the missing data types. This wraps up user list graph work done before the `alpha` --> `beta` merge.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Related to: https://github.com/open-sauced/app/issues/2515

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

N/a: adds missing data points in API:

![Screenshot 2024-01-25 at 11 40 54 AM](https://github.com/open-sauced/app/assets/23109390/5f50d3fc-c5fa-416a-9d0e-83bb868c4530)

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
