### PR TITLE
fix: Uses beta default .env for API

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 NEXT_PUBLIC_SUPABASE_URL=https://fcqqkxwlntnrtjfbcioz.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZjcXFreHdsbnRucnRqZmJjaW96Iiwicm9sZSI6ImFub24iLCJpYXQiOjE2OTg0MTkyNzQsImV4cCI6MjAxMzk5NTI3NH0.ymWWYdnJC2gsnrJx4lZX2cfSOp-1xVuWFGt1Wr6zwtg
-NEXT_PUBLIC_API_URL=https://alpha.api.opensauced.pizza/v2
-NEXT_PUBLIC_EXP_API_URL=https://alpha.api.opensauced.pizza/v2
+NEXT_PUBLIC_API_URL=https://beta.api.opensauced.pizza/v2
+NEXT_PUBLIC_EXP_API_URL=https://beta.api.opensauced.pizza/v2
 NEXT_PUBLIC_POSTHOG_ID=phc_Y0xz6nK55MEwWjobJsI2P8rsiomZJ6eZLoXehmMy9tt
 NEXT_PUBLIC_CLOUD_NAME=dgxgziswe
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "dotenv.enableAutocloaking": false
-}


### PR DESCRIPTION
## Description

Quick-followup to https://github.com/open-sauced/app/pull/2532 and 7fab5eadbac5066f8f7ec16d6804b7d3812ce36b where it looks like the `alpha` API was added as the default env.

Also removes the unnecessary `.vscode` directory that looks to have been added

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Followup to: https://github.com/open-sauced/app/pull/2532

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

Run locally and see `beta.api.opensauced.pizza` being used in network calls

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
