### PR TITLE
Revert "fix: Adding new repos to insights on edit page will trigger another API call"

### DIFF
--- a/lib/hooks/api/useRepositories.ts
+++ b/lib/hooks/api/useRepositories.ts
@@ -5,7 +5,7 @@ import { useRouter } from "next/router";
 import { publicApiFetcher } from "lib/utils/public-api-fetcher";
 import getFilterQuery from "lib/utils/get-filter-query";
 
-export interface PaginatedResponse {
+interface PaginatedResponse {
   readonly data: DbRepo[];
   readonly meta: Meta;
 }
@@ -13,7 +13,7 @@ export interface PaginatedResponse {
 const useRepositories = (repoIds: number[] = [], range = 30, limit = 10) => {
   const router = useRouter();
   const [page, setPage] = useState(1);
-  const [currentRepoIds, setCurrentRepoIds] = useState<number[]>(repoIds);
+
   const { pageId, selectedFilter } = router.query;
   const topic = pageId as string;
   const filterQuery = getFilterQuery(selectedFilter);
@@ -39,10 +39,6 @@ const useRepositories = (repoIds: number[] = [], range = 30, limit = 10) => {
     query.delete("topic");
     query.set("repoIds", repoIds.join(","));
   }
-  if (currentRepoIds?.length > 0) {
-    query.delete("topic");
-    query.set("repoIds", currentRepoIds.join(","));
-  }
 
   if (query.get("repo")) {
     query.delete("topic");
@@ -64,7 +60,6 @@ const useRepositories = (repoIds: number[] = [], range = 30, limit = 10) => {
     mutate,
     page,
     setPage,
-    setCurrentRepoIds,
   };
 };
 

--- a/pages/hub/insights/[insightId]/edit.tsx
+++ b/pages/hub/insights/[insightId]/edit.tsx
@@ -17,7 +17,7 @@ const EditInsightPage: WithPageLayout = () => {
   const { data: insight, isLoading: insightLoading, isError: insightError } = useInsight(id);
   const { isLoading: insightTeamMembersLoading, isError: insightTeamMembersError } = useInsightMembers(Number(id));
   const insightRepos = insight?.repos.map((repo) => repo.repo_id);
-  const { data: repos, meta, mutate, setCurrentRepoIds } = useRepositories(insightRepos, 30, 50);
+  const { data: repos } = useRepositories(insightRepos, 30, 50);
 
   if (insightLoading || insightTeamMembersLoading) {
     return <>Loading</>;
@@ -30,16 +30,8 @@ const EditInsightPage: WithPageLayout = () => {
   if (insightTeamMembersError) {
     return <>Unauthorized</>;
   }
-  return (
-    <InsightPage
-      edit={true}
-      insight={insight}
-      pageRepos={repos}
-      pageReposMeta={meta}
-      mutate={mutate}
-      setCurrentRepoIds={setCurrentRepoIds}
-    />
-  );
+
+  return <InsightPage edit={true} insight={insight} pageRepos={repos} />;
 };
 
 EditInsightPage.PageLayout = HubLayout;


### PR DESCRIPTION
Reverts open-sauced/app#2499

Not sure why the build didn't continue to fail with the type error mentioned, but we need to revisit the usage in the edit page for an insight