### PR TITLE
fix: now if Posthog is down, we return null for feature flags or a user (#2640)

### DIFF
--- a/lib/utils/server/feature-flags.ts
+++ b/lib/utils/server/feature-flags.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/nextjs";
+
 export type FeatureFlag = "contributions_evolution_by_type" | "workspaces";
 
 export async function getAllFeatureFlags(userId: number) {
@@ -16,6 +18,14 @@ export async function getAllFeatureFlags(userId: number) {
     "https://app.posthog.com/decide?v=3", // or eu
     requestOptions
   );
+
+  if (response.status !== 200) {
+    Sentry.captureException(new Error("Posthog is having issues", { cause: response }));
+
+    // Not ideal, but we don't want to block the user if Posthog is down
+    return null;
+  }
+
   const { featureFlags } = await response.json();
 
   if (featureFlags === undefined) {


### PR DESCRIPTION
## Description

Hotfix for production as Posthog is down. This is the same fix as #2640 that got merged to main. This PR cherry picks that commit.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Cherry picked from #2640 prod hotfix
Relates to https://opensauced.sentry.io/issues/4970413146/?project=4505082236960768

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. Ensure you're logged in.
2. The app loads.


## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/l4FATJpd4LWgeruTK/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
