### PR TITLE
fix: prevent onboard button from flashing on mobile screens

### DIFF
--- a/components/organisms/TopNav/top-nav.tsx
+++ b/components/organisms/TopNav/top-nav.tsx
@@ -30,23 +30,19 @@ const TopNav = ({ hideInsights = false }: TopNavProps) => {
       </div>
       <div className="lg:hidden container mx-auto px-2 md:px-16 flex justify-between items-center">
         <Nav name="Mobile" hideInsights={hideInsights} />
-        {user
-          ? !onboarded && (
-              <div className="relative">
-                <OnboardingButton aria="onboarding" className="!flex !pr-1 mb-1 mr-2">
-                  <Text className="text-sm !text-light-slate-12 hidden sm:block py-1 px-2">
-                    Complete the onboarding
-                  </Text>
-                </OnboardingButton>
-                <div id="onboarding" className="flex flex-col absolute right-0 sm:hidden">
-                  <span className="border-x-transparent border-x-[7px] border-b-[7px] border-b-orange-500 h-0 w-0 self-end mr-[1.1rem]" />
-                  <Text className="text-sm py-1 px-2 w-max rounded shadow-lg bg-light-slate-2 !text-light-orange-9 outline-[1px] outline outline-orange-500">
-                    Complete the onboarding
-                  </Text>
-                </div>
-              </div>
-            )
-          : null}
+        {user && onboarded === false && (
+          <div className="relative">
+            <OnboardingButton aria="onboarding" className="!flex !pr-1 mb-1 mr-2">
+              <Text className="text-sm !text-light-slate-12 hidden sm:block py-1 px-2">Complete the onboarding</Text>
+            </OnboardingButton>
+            <div id="onboarding" className="flex flex-col absolute right-0 sm:hidden">
+              <span className="border-x-transparent border-x-[7px] border-b-[7px] border-b-orange-500 h-0 w-0 self-end mr-[1.1rem]" />
+              <Text className="text-sm py-1 px-2 w-max rounded shadow-lg bg-light-slate-2 !text-light-orange-9 outline-[1px] outline outline-orange-500">
+                Complete the onboarding
+              </Text>
+            </div>
+          </div>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
## Description

This PR fixes the Complete onboarding button flashes on mobile screens by preventing it from rendering when `onboarded` is undefined.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #2324 

## Mobile & Desktop Screenshots/Recordings

![onboard-button-fix](https://github.com/open-sauced/app/assets/48654322/1ffaf9a7-3472-4c67-9d13-a4e447159005)


## Steps to QA

1. Navigate to any page on mobile and log in to the app.
2. If you haven't completed the onboarding, go ahead and do that.
3. Reload the page to verify the button doesn't flash.


## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
