### PR TITLE
fix: replaced health with activity ratio

### DIFF
--- a/components/Workspaces/RepositoryStatCard.stories.tsx
+++ b/components/Workspaces/RepositoryStatCard.stories.tsx
@@ -38,7 +38,7 @@ export const Issues: Story = {
 export const Engagement: Story = {
   args: {
     type: "engagement",
-    stats: { stars: 10, forks: 5, health: 2 },
+    stats: { stars: 10, forks: 5, activity_ratio: 2 },
   },
 };
 

--- a/components/Workspaces/RepositoryStatCard.tsx
+++ b/components/Workspaces/RepositoryStatCard.tsx
@@ -1,5 +1,7 @@
+import { ArrowTrendingDownIcon, ArrowTrendingUpIcon, MinusSmallIcon } from "@heroicons/react/24/solid";
 import { GitPullRequestIcon, HeartIcon, IssueOpenedIcon } from "@primer/octicons-react";
 import Card from "components/atoms/Card/card";
+import Pill from "components/atoms/Pill/pill";
 import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
 import humanizeNumber from "lib/utils/humanizeNumber";
 
@@ -53,6 +55,22 @@ function getStatPropertiesByType(type: CardType) {
   }
 }
 
+const getPillChart = (total?: number, loading?: boolean) => {
+  if (total === undefined || loading) {
+    return "-";
+  }
+
+  if (total > 7) {
+    return <Pill icon={<ArrowTrendingUpIcon color="green" className="w-4 h-4" />} text="High" color="green" />;
+  }
+
+  if (total >= 4 && total <= 7) {
+    return <Pill icon={<MinusSmallIcon color="black" className="w-4 h-4" />} text="Medium" color="yellow" />;
+  }
+
+  return <Pill icon={<ArrowTrendingDownIcon color="red" className="w-4 h-4" />} text="Low" color="red" />;
+};
+
 const EmptyState = ({ type, hasError }: { type: CardType; hasError: boolean }) => {
   return (
     <table className="grid gap-4 p-2">
@@ -105,10 +123,7 @@ export const RepositoryStatCard = ({ stats, type, isLoading, hasError }: Reposit
                       {stat.replace("_", " ")}
                     </th>
                     {stat === "activity_ratio" ? (
-                      <td className="text-black semi-bold text-2xl">
-                        {Math.round(value)}
-                        <span className="text-xs">/10</span>
-                      </td>
+                      <td className="text-black semi-bold text-2xl">{getPillChart(Math.round(value), isLoading)}</td>
                     ) : (
                       <td className="semi-bold text-2xl" title={`${value}`}>
                         {stat === "velocity" ? `${Math.round(value)}d` : humanizeNumber(value, "abbreviation")}

--- a/components/Workspaces/RepositoryStatCard.tsx
+++ b/components/Workspaces/RepositoryStatCard.tsx
@@ -17,7 +17,7 @@ type RepositoryStatCardProps = {
     }
   | {
       type: "engagement";
-      stats: { stars: number; forks: number; health: number } | undefined;
+      stats: { stars: number; forks: number; activity_ratio: number } | undefined;
     }
 );
 
@@ -47,7 +47,7 @@ function getStatPropertiesByType(type: CardType) {
     case "issues":
       return ["opened", "closed", "velocity"];
     case "engagement":
-      return ["stars", "forks", "health"];
+      return ["stars", "forks", "activity_ratio"];
     default:
       throw new Error("Invalid repository stat card type");
   }
@@ -102,9 +102,9 @@ export const RepositoryStatCard = ({ stats, type, isLoading, hasError }: Reposit
                 return (
                   <tr key={stat} className="flex flex-col">
                     <th scope="row" className="capitalize font-medium text-sm text-light-slate-11 text-left">
-                      {stat}
+                      {stat.replace("_", " ")}
                     </th>
-                    {stat === "health" ? (
+                    {stat === "activity_ratio" ? (
                       <td className="text-black semi-bold text-2xl">
                         {Math.round(value)}
                         <span className="text-xs">/10</span>

--- a/next-types.d.ts
+++ b/next-types.d.ts
@@ -479,6 +479,6 @@ interface DbWorkspacesReposStats {
   repos: {
     stars: number;
     forks: number;
-    health: number;
+    activity_ratio: number;
   };
 }


### PR DESCRIPTION
## Description

The engagement card on the repositories dashboard page of a workspace now shows the activity ration instead of the health.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #2719

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-02-20 at 13 14 21@2x](https://github.com/open-sauced/app/assets/833231/8683ab69-4d3b-414d-adb9-63d34ab8e30e)

**After**

![CleanShot 2024-02-20 at 14 57 51@2x](https://github.com/open-sauced/app/assets/833231/01030b47-c16b-40f3-a39b-7af380a56f63)


## Steps to QA

1. Ensure you're logged in
2. Navigate to `/`
3. Your last workspace you used loads
4. Notice the engagement stat card has an activity ratio number on 10 instead of a health score.


## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/1lL0ENA9UiySk/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
