### PR TITLE
fix: removed unused feature flags in contributor insights page

### DIFF
--- a/pages/workspaces/[workspaceId]/contributor-insights/index.tsx
+++ b/pages/workspaces/[workspaceId]/contributor-insights/index.tsx
@@ -13,7 +13,6 @@ import ListCard from "components/molecules/ListCard/list-card";
 import { useToast } from "lib/hooks/useToast";
 
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
-import { getAllFeatureFlags } from "lib/utils/server/feature-flags";
 import { WorkspaceLayout } from "components/Workspaces/WorkspaceLayout";
 import { fetchApiData } from "helpers/fetchApiData";
 import { WORKSPACE_ID_COOKIE_NAME } from "lib/utils/workspace-utils";
@@ -43,13 +42,9 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     throw new Error(`Error loading workspaces page with ID ${workspaceId}`);
   }
 
-  const userId = Number(session?.user.user_metadata.sub);
-  const featureFlags = await getAllFeatureFlags(userId);
-
   return {
     props: {
       workspace: data,
-      featureFlags,
     },
   };
 };


### PR DESCRIPTION
## Description

The contributor insights page had feature flags being loaded server-side, but they're never used. This PR removes them to avoid unnecessary calls to Posthog.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #2803

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. Go to the landing page for workspace contributor insights
2. Things should load as they normally do.

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/tTGs5qyvh36jMIDqUO/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
