### PR TITLE
fix: hide UI elements for public workspaces and insights when not logged in

### DIFF
--- a/components/molecules/ListCard/list-card.tsx
+++ b/components/molecules/ListCard/list-card.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Link from "next/link";
 import { MdOutlineArrowForwardIos } from "react-icons/md";
 import { RiDeleteBinLine } from "react-icons/ri";
-import clsx from "clsx";
+import { User } from "@supabase/supabase-js";
 import Text from "components/atoms/Typography/text";
 import { useFetchListContributors } from "lib/hooks/useList";
 import Card from "components/atoms/Card/card";
@@ -12,8 +12,9 @@ interface ListCardProps {
   list: DbUserList;
   handleOnDeleteClick?: (listName: string, listId: string) => void;
   workspaceId?: string;
+  user: User | null;
 }
-const ListCard = ({ list, handleOnDeleteClick, workspaceId }: ListCardProps) => {
+const ListCard = ({ list, handleOnDeleteClick, workspaceId, user }: ListCardProps) => {
   const { data: contributors, meta } = useFetchListContributors(list.id);
 
   const contributorsAvatar: Contributor[] = contributors?.map((contributor) => ({
@@ -37,14 +38,6 @@ const ListCard = ({ list, handleOnDeleteClick, workspaceId }: ListCardProps) => 
                 {list.name}
               </Link>
             </div>
-            <div
-              className={clsx(
-                "px-2 border rounded-2xl text-light-slate-11",
-                !handleOnDeleteClick ? "text-orange-700 bg-orange-50 border-orange-600" : ""
-              )}
-            >
-              {handleOnDeleteClick ? (!!list.is_public ? "public" : "private") : "demo"}
-            </div>
           </div>
         </div>
         <div>
@@ -60,7 +53,7 @@ const ListCard = ({ list, handleOnDeleteClick, workspaceId }: ListCardProps) => 
             </div>
             <div className="justify-end flex-1 hidden md:flex">
               {/* Delete button */}
-              {handleOnDeleteClick && (
+              {handleOnDeleteClick && !!user && (
                 <button
                   onClick={() => handleOnDeleteClick(list.name, list.id)}
                   className="inline-block p-3 mr-2 border rounded-lg cursor-pointer bg-light-slate-1"

--- a/components/molecules/WorkspaceRepositoryInsightRow/workspace-repository-insight-row.tsx
+++ b/components/molecules/WorkspaceRepositoryInsightRow/workspace-repository-insight-row.tsx
@@ -4,7 +4,6 @@ import { BsPencilFill } from "react-icons/bs";
 import { MdOutlineArrowForwardIos } from "react-icons/md";
 import { User } from "@supabase/supabase-js";
 
-import clsx from "clsx";
 import { getRelativeDays } from "lib/utils/date-utils";
 import useRepositories from "lib/hooks/api/useRepositories";
 import getRepoInsights from "lib/utils/get-repo-insights";
@@ -37,7 +36,7 @@ const WorkspaceRepositoryInsightRow = ({
   const { open, merged, velocity, total, repoList } = getRepoInsights(repoData);
   const avgOpenPrs = repoData.length > 0 ? Math.round(open / repoData.length) : 0;
 
-  const membership = workspaceMembers?.find((member) => member.user_id === Number(user?.id));
+  const membership = workspaceMembers?.find((member) => Number(member.user_id) === Number(user?.user_metadata.sub));
   const canEdit = membership && ["owner", "editor"].includes(membership.role);
   const publicLinkPrefix = `/workspaces/${workspaceId}/repository-insights`;
   const editLinkPrefix = `/workspaces/${workspaceId}/repository-insights`;
@@ -57,15 +56,7 @@ const WorkspaceRepositoryInsightRow = ({
                 {isEditable ? insight?.name : `Demo | ${insight?.name}`}
               </Link>
             </div>
-            <div
-              className={clsx(
-                "rounded-2xl border px-2 text-light-slate-11",
-                !isEditable ? "text-orange-700 bg-orange-50 border-orange-600" : ""
-              )}
-            >
-              {!isEditable ? "demo" : !!insight?.is_public ? "public" : "private"}
-            </div>
-            {isEditable ? (
+            {canEdit ? (
               <div className="flex-1 md:hidden">
                 <span className=" bg-light-slate-1 inline-block rounded-lg p-2.5 border mr-2">
                   <Link href={`${editLinkPrefix}/${insight?.id}/edit`}>
@@ -111,7 +102,7 @@ const WorkspaceRepositoryInsightRow = ({
               </div>
             </div>
             <div className="flex-1 hidden md:flex  justify-end">
-              {canEdit || (
+              {canEdit && (
                 <Link href={`${editLinkPrefix}/${insight?.id}/edit`}>
                   <span className=" bg-light-slate-1 inline-block rounded-lg p-2.5 border mr-2 cursor-pointer">
                     <BsPencilFill title="Edit Insight Page" className="text-light-slate-10 text-lg" />

--- a/components/shared/AppSidebar/AppSidebar.tsx
+++ b/components/shared/AppSidebar/AppSidebar.tsx
@@ -52,11 +52,12 @@ interface AppSideBarProps {
 }
 
 export const AppSideBar = ({ workspaceId, hideSidebar, sidebarCollapsed }: AppSideBarProps) => {
+  const { user } = useSupabaseAuth();
   const { data: rawRepoInsights, isLoading: repoInsightsLoading } = useWorkspacesRepositoryInsights({ workspaceId });
   const { data: rawContributorInsights, isLoading: contributorInsightsLoading } = useWorkspacesContributorInsights({
     workspaceId,
   });
-  const { data: workspaces, isLoading: workspacesLoading, mutate } = useWorkspaces({ limit: 100 });
+  const { data: workspaces, isLoading: workspacesLoading, mutate } = useWorkspaces({ load: !!user, limit: 100 });
   const router = useRouter();
 
   const repoInsights = rawRepoInsights
@@ -84,7 +85,7 @@ export const AppSideBar = ({ workspaceId, hideSidebar, sidebarCollapsed }: AppSi
       document.removeEventListener(WORKSPACE_UPDATED_EVENT, mutateHandler);
     };
   });
-  const { user } = useSupabaseAuth();
+
   const { data: gitHubUser } = useFetchUser(user?.user_metadata.user_name);
   const userInterest = gitHubUser?.interests.split(",")[0] || "javascript";
 
@@ -131,52 +132,56 @@ export const AppSideBar = ({ workspaceId, hideSidebar, sidebarCollapsed }: AppSi
         </div>
         {workspaceId === "new" ? null : (
           <ul className="grid gap-1 mb-6">
-            <SidebarMenuItem
-              title="Home"
-              url={`/workspaces/${workspaceId}`}
-              icon={<BiHomeAlt className="w-5 h-5 text-slate-400" />}
-            />
-            <li className="flex flex-row justify-between items-center ">
-              <h3 className="uppercase text-gray-500 text-xs font-medium tracking-wide px-2">Insights</h3>
-              <DropdownMenu modal={false}>
-                <DropdownMenuTrigger title="Select type of new insight">
-                  <PlusIcon
-                    style={{ strokeWidth: "3px" }}
-                    className="w-5 h-5 p-0.5 text-semibold group-hover:bg-orange-100 rounded-md"
-                  />
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  side="right"
-                  align="start"
-                  className="sidebar-new-insights-menu flex flex-col gap-1 py-2 rounded-lg shadow-xl"
-                >
-                  <DropdownMenuItem className="rounded-md group">
-                    <Link
-                      title="New Repository Insight"
-                      href={`/workspaces/${workspaceId}/repository-insights/new`}
-                      className="text-sm font-medium flex gap-1 items-center rounded-md transition-colors cursor-pointer tracking-tight p-1"
-                    >
-                      <ChartBarSquareIcon className="w-5 h-5 text-slate-400 inline-flex mr-1 group-hover:stroke-orange-500" />
-                      <span className="whitespace-nowrap overflow-hidden overflow-ellipsis inline-flex">
-                        New Repository Insight
-                      </span>
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem className="rounded-md group">
-                    <Link
-                      title="New Contributor Insight"
-                      href={`/workspaces/${workspaceId}/contributor-insights/new`}
-                      className="text-sm font-medium flex gap-1 items-center rounded-md transition-colors cursor-pointer tracking-tight p-1"
-                    >
-                      <UsersIcon className="w-5 h-5 text-slate-400 inline-flex mr-1 group-hover:stroke-orange-500" />
-                      <span className="whitespace-nowrap overflow-hidden overflow-ellipsis inline-flex">
-                        New Contributor Insight
-                      </span>
-                    </Link>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </li>
+            {!!user && (
+              <SidebarMenuItem
+                title="Home"
+                url={`/workspaces/${workspaceId}`}
+                icon={<BiHomeAlt className="w-5 h-5 text-slate-400" />}
+              />
+            )}
+            {!!user && (
+              <li className="flex flex-row justify-between items-center ">
+                <h3 className="uppercase text-gray-500 text-xs font-medium tracking-wide px-2">Insights</h3>
+                <DropdownMenu modal={false}>
+                  <DropdownMenuTrigger title="Select type of new insight">
+                    <PlusIcon
+                      style={{ strokeWidth: "3px" }}
+                      className="w-5 h-5 p-0.5 text-semibold group-hover:bg-orange-100 rounded-md"
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    side="right"
+                    align="start"
+                    className="sidebar-new-insights-menu flex flex-col gap-1 py-2 rounded-lg shadow-xl"
+                  >
+                    <DropdownMenuItem className="rounded-md group">
+                      <Link
+                        title="New Repository Insight"
+                        href={`/workspaces/${workspaceId}/repository-insights/new`}
+                        className="text-sm font-medium flex gap-1 items-center rounded-md transition-colors cursor-pointer tracking-tight p-1"
+                      >
+                        <ChartBarSquareIcon className="w-5 h-5 text-slate-400 inline-flex mr-1 group-hover:stroke-orange-500" />
+                        <span className="whitespace-nowrap overflow-hidden overflow-ellipsis inline-flex">
+                          New Repository Insight
+                        </span>
+                      </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem className="rounded-md group">
+                      <Link
+                        title="New Contributor Insight"
+                        href={`/workspaces/${workspaceId}/contributor-insights/new`}
+                        className="text-sm font-medium flex gap-1 items-center rounded-md transition-colors cursor-pointer tracking-tight p-1"
+                      >
+                        <UsersIcon className="w-5 h-5 text-slate-400 inline-flex mr-1 group-hover:stroke-orange-500" />
+                        <span className="whitespace-nowrap overflow-hidden overflow-ellipsis inline-flex">
+                          New Contributor Insight
+                        </span>
+                      </Link>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </li>
+            )}
             <li className="grid gap-2">
               <InsightsPanel
                 title="Repository Insights"

--- a/lib/hooks/api/useWorkspaces.ts
+++ b/lib/hooks/api/useWorkspaces.ts
@@ -8,7 +8,7 @@ interface PaginatedResponse {
   readonly meta: Meta;
 }
 
-const useWorkspaces = ({ limit = 100 }: { limit?: number }) => {
+const useWorkspaces = ({ load = false, limit = 100 }: { load?: boolean; limit?: number }) => {
   const [page, setPage] = useState(1);
   const query = new URLSearchParams();
   query.append("page", `${page}`);
@@ -18,7 +18,7 @@ const useWorkspaces = ({ limit = 100 }: { limit?: number }) => {
   const endpointString = `${baseEndpoint}?${query}`;
 
   const { data, error, mutate } = useSWR<PaginatedResponse, Error>(
-    endpointString,
+    load ? endpointString : null,
     publicApiFetcher as Fetcher<PaginatedResponse, Error>
   );
 

--- a/pages/hub/lists/index.tsx
+++ b/pages/hub/lists/index.tsx
@@ -40,7 +40,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 const DeleteListPageModal = dynamic(() => import("components/organisms/ListPage/DeleteListPageModal"));
 
 const ListsHub: WithPageLayout = () => {
-  const { sessionToken } = useSupabaseAuth();
+  const { sessionToken, user } = useSupabaseAuth();
   const { data, isLoading, meta, setPage, mutate } = useFetchAllLists(30, !!sessionToken);
   const { data: featuredListsData, isLoading: featuredListsLoading } = useFetchFeaturedLists(
     sessionToken ? false : true
@@ -105,6 +105,7 @@ const ListsHub: WithPageLayout = () => {
                 updated_at: "",
                 is_public: is_public,
               }}
+              user={user}
             />
           ))
         ) : (
@@ -129,6 +130,7 @@ const ListsHub: WithPageLayout = () => {
               updated_at: "",
               is_public: list.is_public,
             }}
+            user={user}
           />
         ))}
       </section>

--- a/pages/workspaces/[workspaceId]/contributor-insights/index.tsx
+++ b/pages/workspaces/[workspaceId]/contributor-insights/index.tsx
@@ -53,7 +53,7 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
 const DeleteListPageModal = dynamic(() => import("components/organisms/ListPage/DeleteListPageModal"));
 
 const ListsHub = ({ workspace }: { workspace: Workspace }) => {
-  const { sessionToken } = useSupabaseAuth();
+  const { sessionToken, user } = useSupabaseAuth();
   const { data, isLoading, meta, setPage, mutate } = useWorkspacesContributorInsights({ workspaceId: workspace.id });
   const { toast } = useToast();
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
@@ -121,6 +121,7 @@ const ListsHub = ({ workspace }: { workspace: Workspace }) => {
                   is_public: is_public,
                 }}
                 workspaceId={workspace.id}
+                user={user}
               />
             ))
           ) : (

--- a/pages/workspaces/[workspaceId]/repository-insights/index.tsx
+++ b/pages/workspaces/[workspaceId]/repository-insights/index.tsx
@@ -47,32 +47,30 @@ const RepositoryInsights = () => {
           <div className="text-3xl leading-none mx-0">Repository Insights</div>
         </nav>
         <section className="flex flex-col gap-4 pt-4">
-          {user ? (
-            <>
-              {session && isLoading ? (
-                <SkeletonWrapper count={3} classNames="w-full" height={95} radius={10} />
-              ) : isError ? (
-                "Error..."
-              ) : data && data.length > 0 ? (
-                data.map((insight) => {
-                  return (
-                    <WorkspaceRepositoryInsightRow
-                      key={`insights_${insight.id}`}
-                      user={user}
-                      workspaceInsight={insight}
-                      workspaceId={workspaceId}
-                    />
-                  );
-                })
-              ) : (
-                <div className="flex flex-col items-center justify-center w-full gap-4 ">
-                  {!isLoading && sessionToken ? (
-                    <Title className="text-2xl">You currently have no repository insights</Title>
-                  ) : null}
-                </div>
-              )}
-            </>
-          ) : null}
+          <>
+            {session && isLoading ? (
+              <SkeletonWrapper count={3} classNames="w-full" height={95} radius={10} />
+            ) : isError ? (
+              "Error..."
+            ) : data && data.length > 0 ? (
+              data.map((insight) => {
+                return (
+                  <WorkspaceRepositoryInsightRow
+                    key={`insights_${insight.id}`}
+                    user={user}
+                    workspaceInsight={insight}
+                    workspaceId={workspaceId}
+                  />
+                );
+              })
+            ) : (
+              <div className="flex flex-col items-center justify-center w-full gap-4 ">
+                {!isLoading && sessionToken ? (
+                  <Title className="text-2xl">You currently have no repository insights</Title>
+                ) : null}
+              </div>
+            )}
+          </>
         </section>
 
         <div


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
- Fixes UI elements being displayed when not logged in for contributor/repository insights
- Removes public/private indicators from contributor/repository insights as its handled at the workspace level
- Removes edit/delete buttons from contributor/repository list pages when not authenticated
- Does not load workspaces into the sidebar if not authenticated
- Hides the Home and Create New Insight buttons if not authenticated

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes https://github.com/open-sauced/app/issues/2837

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

<img width="1240" alt="image" src="https://github.com/open-sauced/app/assets/42211/4aee26cf-a8ea-4fc8-a6cc-fda4ad30ae6d">

<img width="1240" alt="image" src="https://github.com/open-sauced/app/assets/42211/0f238dae-fc82-415c-95e4-dce651bfd012">

<img width="1240" alt="image" src="https://github.com/open-sauced/app/assets/42211/7894f393-e144-4c24-9975-9d50a093f26d">


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
1. Go to deploy preview without logging in
2. Navigate to https://deploy-preview-2840--oss-insights.netlify.app//pages/brandonroberts/346/dashboard
3. Get redirected to the public workspace
4. Note empty workspaces list
5. Note no Home button in sidebar
6. Note Repository/contributor insights are listed without edit/delete buttons

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/V1NxC1YoNEHBe/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
