### PR TITLE
chore: removes "pr_velocity" from lists contrib search

### DIFF
--- a/lib/hooks/useFetchAllContributors.ts
+++ b/lib/hooks/useFetchAllContributors.ts
@@ -10,7 +10,6 @@ interface PaginatedResponse {
 
 type QueryObj = {
   location?: string;
-  pr_velocity?: string;
   timezone?: string;
   initialLimit?: number;
   contributor?: string;
@@ -27,9 +26,6 @@ const useFetchAllContributors = (query: QueryObj, config?: SWRConfiguration, mak
   }
   if (query.location) {
     urlQuery.set("location", `${query.location}`);
-  }
-  if (query.pr_velocity) {
-    urlQuery.set("pr_velocity", `${query.pr_velocity}`);
   }
   if (query.timezone) {
     urlQuery.set("timezone", `${query.timezone}`);


### PR DESCRIPTION
## Description

Removes the unused `pr_velocity` in the list contribs search as we're removing usage of our first party `pull_request` table - see https://github.com/open-sauced/api/pull/674 for more details

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [x] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Followup to https://github.com/open-sauced/api/pull/674

## Mobile & Desktop Screenshots/Recordings

## Steps to QA

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdmxuMGI2dmRhN2FtM2VqMjZhcGt3cnhyazA2emh0cHkybHd2dnJibiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/wYpAennWlMLR5O4Xd2/giphy-downsized.gif)

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
