### PR TITLE
fix: removed unnecessary alt text on logo and cleaned up JSX

### DIFF
--- a/components/molecules/HeaderLogo/header-logo.tsx
+++ b/components/molecules/HeaderLogo/header-logo.tsx
@@ -12,22 +12,15 @@ interface HeaderLogoProps {
 
 const HeaderLogo: React.FC<HeaderLogoProps> = ({ textIsBlack, withBg = false, responsive }) => {
   return (
-    <Link href="/">
-      <div className="flex items-center py-2 gap-2 cursor-pointer">
-        <Image
-          className="rounded"
-          alt="OpenSauced Logo"
-          width={20}
-          src={withBg ? openSaucedImgWithBg : openSaucedImg}
-        />
-        <p
-          className={`font-bold text-lg tracking-tight ${textIsBlack ? "!text-black" : "!text-white"} ${
-            responsive ? "hidden sm:block" : ""
-          }`}
-        >
-          OpenSauced
-        </p>
-      </div>
+    <Link href="/" className="flex items-center py-2 gap-2 cursor-pointer">
+      <Image className="rounded" alt="" width={20} src={withBg ? openSaucedImgWithBg : openSaucedImg} />
+      <span
+        className={`font-bold text-lg tracking-tight ${textIsBlack ? "!text-black" : "!text-white"} ${
+          responsive ? "hidden sm:block" : ""
+        }`}
+      >
+        OpenSauced
+      </span>
     </Link>
   );
 };


### PR DESCRIPTION
## Description

Removes unnecessary markup from the header logo and removes unnecessary alt text on the logo image.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #3012

## Mobile & Desktop Screenshots/Recordings

The header logo looks the same so nothing to show.

## Steps to QA

1. Navigate to `/`.
2. The header logo looks the same as the one on https://app.opensauced.pizza

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/P8yl3NNvMc2sViu8WI/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
