### PR TITLE
style: un-fix top-nav on mobile

### DIFF
--- a/components/organisms/TopNav/top-nav.tsx
+++ b/components/organisms/TopNav/top-nav.tsx
@@ -17,7 +17,7 @@ const TopNav = () => {
   const { onboarded } = useSession();
 
   return (
-    <header className="top-nav-container w-full fixed top-0 left-0 z-50 py-0.5 bg-light-slate-2 border-b px-2">
+    <header className="top-nav-container w-full sm:fixed top-0 left-0 z-50 py-0.5 bg-light-slate-2 border-b px-2">
       <div className="flex gap-2 justify-between items-center mx-auto px-2">
         <div className="flex gap-3 md:gap-8 items-center">
           <HeaderLogo responsive={true} withBg={false} textIsBlack />


### PR DESCRIPTION
## Description

This PR :
 - un-fixes the navbar on mobile version
 - makes the top navbar scroll with the rest of the page instead of keeping it fixed (only on mobile).


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

Fixes  #2995

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed




