### PR TITLE
fix: remove useEffectOnce and check if upgrade modal is open before logging

### DIFF
--- a/components/Workspaces/InsightUpgradeModal.tsx
+++ b/components/Workspaces/InsightUpgradeModal.tsx
@@ -1,7 +1,6 @@
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 import { FaRegCheckCircle } from "react-icons/fa";
 import { usePostHog } from "posthog-js/react";
-import { useEffectOnce } from "react-use";
 import { Dialog, DialogTitle, DialogContent, DialogCloseButton } from "components/molecules/Dialog/dialog";
 import Button from "components/shared/Button/button";
 import Card from "components/atoms/Card/card";
@@ -23,9 +22,11 @@ export default function InsightUpgradeModal({
 }: InsightUpgradeModalProps) {
   const posthog = usePostHog();
 
-  useEffectOnce(() => {
-    posthog.capture("clicked: Upgrade Workspace Modal", { workspaceId });
-  });
+  useEffect(() => {
+    if (isOpen) {
+      posthog.capture("clicked: Upgrade Workspace Modal", { workspaceId });
+    }
+  }, [isOpen]);
 
   return (
     <Dialog open={isOpen}>

--- a/components/Workspaces/WorkspaceBanner.tsx
+++ b/components/Workspaces/WorkspaceBanner.tsx
@@ -1,5 +1,5 @@
 import { usePostHog } from "posthog-js/react";
-import { useEffectOnce } from "react-use";
+import { useEffect } from "react";
 
 type WorkspaceBannerProps = {
   workspaceId: string;
@@ -9,9 +9,9 @@ type WorkspaceBannerProps = {
 export default function WorkspaceBanner({ workspaceId, openModal }: WorkspaceBannerProps) {
   const posthog = usePostHog();
 
-  useEffectOnce(() => {
+  useEffect(() => {
     posthog.capture("shown: Upgrade Workspace Banner", { workspaceId });
-  });
+  }, []);
 
   return (
     <button


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
- Fixes error shown when visiting a repository insight that needs to display the upgrade banner
- Correctly tracks when the insight upgrade modal is clicked
- Removes usage of useEffectOnce which was causing a hook rendering order error

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Closes https://github.com/open-sauced/engineering/issues/274

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
1. Login
2. Go a non-upgraded workspace that has over 10 contributors in an contributor or 100 repositories in a repository insight
3. Note the upgrade banner is shown without an error
4. Click on the upgrade button
5. Note the upgrade modal is shown without an error

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
