### PR TITLE
fix: enable edit and changing of name of contributor insight

### DIFF
--- a/pages/workspaces/[workspaceId]/contributor-insights/[listId]/edit.tsx
+++ b/pages/workspaces/[workspaceId]/contributor-insights/[listId]/edit.tsx
@@ -321,7 +321,7 @@ export default function EditListPage({ list, workspaceId, initialContributors }:
             const form = event.target as HTMLFormElement;
             const listUpdates = {
               name: form["list_name"].value,
-              is_public: form["is_public"].checked,
+              is_public: true,
               contributors: [],
             } satisfies UpdateListPayload;
 


### PR DESCRIPTION
## Description

This PR fixes bug on editing and changing of the name of contributor insight

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
Closes #3049 

## Mobile & Desktop Screenshots/Recordings




## Steps to QA

1. edit the name of a contributor insight
2. it saves the changes


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [ ] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
