### PR TITLE
fix: removed repo-page feature flag from repos page and the project

### DIFF
--- a/e2e/repo-page.spec.ts
+++ b/e2e/repo-page.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test";
+
+test("Loads a repository page", async ({ page }) => {
+  await page.goto("/s/open-sauced/app");
+
+  await expect(page.getByRole("heading", { name: "open-sauced/app", exact: true })).toBeVisible();
+  await expect(page.getByRole("combobox", { name: "Period:", exact: true, expanded: false })).toBeVisible();
+});

--- a/lib/utils/server/feature-flags.ts
+++ b/lib/utils/server/feature-flags.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 
-export type FeatureFlag = "contributions_evolution_by_type" | "repo-pages";
+export type FeatureFlag = "contributions_evolution_by_type";
 
 export async function getAllFeatureFlags(userId: number) {
   const requestOptions = {

--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -2,7 +2,6 @@ import { GetServerSidePropsContext } from "next";
 import { createPagesServerClient } from "@supabase/auth-helpers-nextjs";
 import { useRouter } from "next/router";
 import { fetchApiData } from "helpers/fetchApiData";
-import { getAllFeatureFlags } from "lib/utils/server/feature-flags";
 import { useFetchMetricStats } from "lib/hooks/api/useFetchMetricStats";
 
 import SEO from "layouts/SEO/SEO";
@@ -19,17 +18,11 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     data: { session },
   } = await supabase.auth.getSession();
 
-  const userId = Number(session?.user.user_metadata.sub);
-  if (!userId) {
-    return { notFound: true };
-  }
-
-  const featureFlags = await getAllFeatureFlags(userId);
   const { data: repoData, error } = await fetchApiData<DbRepo>({
     path: `repos/${org}/${repo}`,
   });
 
-  if (!featureFlags["repo-page"] || !repoData || error) {
+  if (!repoData || error) {
     return { notFound: true };
   }
 


### PR DESCRIPTION
## Description

Removes the `"repo-page"` feature flag from the repository page as well as the requirement to be logged in to view the page.

## Related Tickets & Documents

Fixes #3079
Relates to #2988

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. Logged out, visit `/s/open-sauced/app`.
2. The repository page for the OpenSauced app repository loads.


## Tier (staff will fill in)

- [ ] Tier 1
- [x] Tier 2
- [ ] Tier 3
- [ ] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?

Remove the feature flag from Posthog once this is deployed to production.

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
