### PR TITLE
fix: fixed issue where stars metric chart was flipping horizontally

### DIFF
--- a/components/Graphs/MetricCard.tsx
+++ b/components/Graphs/MetricCard.tsx
@@ -9,7 +9,7 @@ type MetricCardProps = {
   range: 7 | 30 | 90;
 };
 
-export default function MetricCard({ stats, variant }: MetricCardProps) {
+export default function MetricCard({ stats, variant, range }: MetricCardProps) {
   const countProperty = variant === "stars" ? "star_count" : "forks_count";
   const seriesData = stats?.map((stat) => stat[countProperty] ?? 0) ?? [];
   const bucketData = stats?.map((stat) => new Date(stat.bucket).toDateString()) ?? [];

--- a/components/Graphs/MetricCard.tsx
+++ b/components/Graphs/MetricCard.tsx
@@ -11,10 +11,9 @@ type MetricCardProps = {
 };
 
 export default function MetricCard({ stats, variant }: MetricCardProps) {
-  const seriesData = stats
-    ?.map((stat) => (variant === "stars" ? stat.star_count || 0 : stat.forks_count || 0))
-    .reverse();
-  const bucketData = stats?.map((stat) => new Date(stat.bucket).toDateString()).reverse();
+  const countProperty = variant === "stars" ? "star_count" : "forks_count";
+  const seriesData = stats?.map((stat) => stat[countProperty] ?? 0) ?? [];
+  const bucketData = stats?.map((stat) => new Date(stat.bucket).toDateString()) ?? [];
 
   const option = {
     xAxis: {

--- a/components/Graphs/MetricCard.tsx
+++ b/components/Graphs/MetricCard.tsx
@@ -1,4 +1,5 @@
 import EChartsReact from "echarts-for-react";
+import { useMemo } from "react";
 import { StatsType } from "lib/hooks/api/useFetchMetricStats";
 import Card from "components/atoms/Card/card";
 import humanizeNumber from "lib/utils/humanizeNumber";
@@ -11,36 +12,41 @@ type MetricCardProps = {
 
 export default function MetricCard({ stats, variant, range }: MetricCardProps) {
   const countProperty = variant === "stars" ? "star_count" : "forks_count";
-  const seriesData = stats?.map((stat) => stat[countProperty] ?? 0) ?? [];
-  const bucketData = stats?.map((stat) => new Date(stat.bucket).toDateString()) ?? [];
+  const seriesData = useMemo(() => stats?.map((stat) => stat[countProperty] ?? 0) ?? [], [countProperty, stats]);
+  const bucketData = useMemo(() => stats?.map((stat) => new Date(stat.bucket).toDateString()) ?? [], [stats]);
 
-  const option = {
-    xAxis: {
-      type: "category",
-      data: bucketData,
-      show: false,
-    },
-    yAxis: {
-      type: "value",
-      show: false,
-    },
-    tooltip: {
-      trigger: "axis",
-      axisPointer: {
-        type: "shadow",
+  const option = useMemo(() => {
+    return {
+      xAxis: {
+        type: "category",
+        data: bucketData,
+        show: false,
       },
-    },
-    series: [
-      {
-        data: seriesData,
-        symbol: "none",
-        type: variant === "stars" ? "line" : "bar",
+      yAxis: {
+        type: "value",
+        show: false,
       },
-    ],
-    color: "hsla(19, 100%, 50%, 1)",
-  };
+      tooltip: {
+        trigger: "axis",
+        axisPointer: {
+          type: "shadow",
+        },
+      },
+      series: [
+        {
+          data: seriesData,
+          symbol: "none",
+          type: variant === "stars" ? "line" : "bar",
+        },
+      ],
+      color: "hsla(19, 100%, 50%, 1)",
+    };
+  }, [bucketData, seriesData, variant]);
 
-  const total = seriesData?.reduce((stat, currentValue) => (stat || 0) + (currentValue || 0), 0);
+  const total = useMemo(
+    () => seriesData?.reduce((stat, currentValue) => (stat || 0) + (currentValue || 0), 0),
+    [seriesData]
+  );
 
   return (
     <Card className="w-full xl:max-w-lg h-fit p-5 pl-6">

--- a/components/Graphs/MetricCard.tsx
+++ b/components/Graphs/MetricCard.tsx
@@ -11,9 +11,10 @@ type MetricCardProps = {
 };
 
 export default function MetricCard({ stats, variant }: MetricCardProps) {
-  const data = stats?.slice() ?? [];
-  const seriesData = data.map((stat) => (variant === "stars" ? stat.star_count || 0 : stat.forks_count || 0)).reverse();
-  const bucketData = data.map((stat) => new Date(stat.bucket).toDateString()).reverse();
+  const seriesData = stats
+    ?.map((stat) => (variant === "stars" ? stat.star_count || 0 : stat.forks_count || 0))
+    .reverse();
+  const bucketData = stats?.map((stat) => new Date(stat.bucket).toDateString()).reverse();
 
   const option = {
     xAxis: {

--- a/components/Graphs/MetricCard.tsx
+++ b/components/Graphs/MetricCard.tsx
@@ -11,10 +11,9 @@ type MetricCardProps = {
 };
 
 export default function MetricCard({ stats, variant }: MetricCardProps) {
-  const seriesData = stats
-    ?.map((stat) => (variant === "stars" ? stat.star_count || 0 : stat.forks_count || 0))
-    .reverse();
-  const bucketData = stats?.map((stat) => new Date(stat.bucket).toDateString()).reverse();
+  const data = stats?.slice() ?? [];
+  const seriesData = data.map((stat) => (variant === "stars" ? stat.star_count || 0 : stat.forks_count || 0)).reverse();
+  const bucketData = data.map((stat) => new Date(stat.bucket).toDateString()).reverse();
 
   const option = {
     xAxis: {

--- a/lib/hooks/api/useFetchMetricStats.ts
+++ b/lib/hooks/api/useFetchMetricStats.ts
@@ -5,6 +5,7 @@ type UseFetchMetricStatsParams = {
   repository: string;
   variant: "stars" | "forks"; // TODO: add other MetricCard types
   range: number;
+  orderDirection?: "ASC" | "DESC";
 };
 
 export type StatsType = {
@@ -13,10 +14,11 @@ export type StatsType = {
   forks_count?: number;
 };
 
-export function useFetchMetricStats({ repository, variant, range }: UseFetchMetricStatsParams) {
+export function useFetchMetricStats({ repository, variant, range, orderDirection = "ASC" }: UseFetchMetricStatsParams) {
   const query = new URLSearchParams();
   query.set("repo", repository);
   query.set("range", range.toString());
+  query.set("orderDirection", orderDirection);
 
   const endpoint = () => {
     switch (variant) {


### PR DESCRIPTION
## Description

Fixes the "flippening" issue that @jpmcb reported.

## Related Tickets & Documents

Fixes #3073

## Mobile & Desktop Screenshots/Recordings

**Before**

![the-flippening](https://github.com/open-sauced/app/assets/23109390/f4e8e851-f41a-4af3-965d-cf08f52a037c)

**After**

![CleanShot 2024-04-02 at 14 34 22](https://github.com/open-sauced/app/assets/833231/9d08d920-9b20-4a8e-b6e7-e005cb0a3038)

## Steps to QA

1. Visit https://deploy-preview-3091--oss-insights.netlify.app/s/kubernetes/kubernetes
2. Go to another browser tab
3. Come back to the tab that has https://deploy-preview-3091--oss-insights.netlify.app/s/kubernetes/kubernetes
4. The graphs no longer flip.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [x] Tier 3
- [ ] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
