### PR TITLE
fix: now repo page charts no longer bleed out of their container

### DIFF
--- a/components/Graphs/MetricCard.tsx
+++ b/components/Graphs/MetricCard.tsx
@@ -54,9 +54,9 @@ export default function MetricCard({ stats, variant, range }: MetricCardProps) {
         {variant} <span className="font-medium text-base text-slate-500">{range} days</span>
       </h2>
 
-      <div className="flex justify-between items-center px-2 gap-8">
+      <div className="flex justify-between items-center px-2 gap-4 md:gap-8">
         <p className="text-5xl font-bold">{humanizeNumber(total!, "abbreviation")}</p>
-        <div className="h-fit w-full pl-6">
+        <div className="h-fit">
           <EChartsReact option={option} style={{ height: "100%", width: "100%" }} />
         </div>
       </div>

--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -55,7 +55,7 @@ export default function RepoPage({ repoData, image }: { repoData: DbRepo; image:
   return (
     <ProfileLayout>
       <SEO title={`${repoData.full_name} - OpenSauced Insights`} />
-      <section className="px-2 pt-2 md:pt-4 md:px-4 flex flex-col gap-8 w-full xl:max-w-6xl">
+      <section className="px-2 pt-2 md:pt-4 md:px-4 flex flex-col gap-2 md:gap-4 lg:gap-8 w-full xl:max-w-6xl">
         <header className="flex items-center gap-4">
           <Avatar size={96} avatarURL={image} />
           <div className="flex flex-col gap-2">
@@ -64,7 +64,7 @@ export default function RepoPage({ repoData, image }: { repoData: DbRepo; image:
           </div>
         </header>
         <DayRangePicker />
-        <section className="flex flex-col gap-2 lg:flex-row lg:gap-8 w-full justify-between">
+        <section className="flex flex-col gap-2 md:gap-4 lg:gap-8 lg:flex-row w-full justify-between">
           <ClientOnly>
             <MetricCard variant="stars" stats={starsData} range={range} />
             <MetricCard variant="forks" stats={forkStats} range={range} />


### PR DESCRIPTION
## Description

Fixes an issues where the metric cards on the repository page were spilling out of their containers.

## Related Tickets & Documents

Fixes #3114

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-04-04 at 08 14 38](https://github.com/open-sauced/app/assets/833231/2467684f-1942-4e2c-96e6-fa4624e1606b)

**After**

![CleanShot 2024-04-04 at 08 13 56](https://github.com/open-sauced/app/assets/833231/6080ef83-823e-4d6a-9635-9a6608ae424b)

## Steps to QA

1. Visit http://localhost:3000/s/kubernetes/kubernetes on a small screen.
2. Notice the metric cards no longer have their graphs bleed out.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/6iJl9K0QbYFHMC7Vhm/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
