### PR TITLE
chore: adjust Sentry configuration and add explicit DSN

### DIFF
--- a/.env
+++ b/.env
@@ -8,6 +8,7 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=test
 NEXT_PUBLIC_STRIPE_SUB_CANCEL_URL=https://billing.stripe.com/p/login/test_bIY8xy3iy6fpeHu3cc
 NEXT_PUBLIC_OPENGRAPH_URL=https://beta.opengraph.opensauced.pizza/v1
 SENTRY_DSN=https://3f5bb9023ff0407299dd22a6454558f9@o4504872488927232.ingest.sentry.io/4505082236960768
+NEXT_PUBLIC_SENTRY_DSN=https://3f5bb9023ff0407299dd22a6454558f9@o4504872488927232.ingest.sentry.io/4505082236960768
 
 # --------------
 # For running the API local, use your devices localhost address:

--- a/next.config.js
+++ b/next.config.js
@@ -135,7 +135,7 @@ module.exports = withSentryConfig(
     silent: true,
 
     org: "opensauced",
-    project: "insights",
+    project: process.env.NODE_ENV === "production" ? "app-opensauced" : "beta-app-opensauced",
   },
   {
     // For all available options, see:
@@ -145,7 +145,7 @@ module.exports = withSentryConfig(
     widenClientFileUpload: true,
 
     // Transpiles SDK to be compatible with IE11 (increases bundle size)
-    transpileClientSDK: true,
+    transpileClientSDK: false,
 
     // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers (increases server load)
     tunnelRoute: "/monitoring",

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -5,6 +5,8 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
+  dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
+
   enabled: process.env.NODE_ENV !== "development",
 
   // Adjust this value in production, or use tracesSampler for greater control

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -6,10 +6,12 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
+  dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
+
   enabled: process.env.NODE_ENV !== "development",
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 0.1,
+  tracesSampleRate: 1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,10 +5,12 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
+  dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
+
   enabled: process.env.NODE_ENV !== "development",
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 0.25,
+  tracesSampleRate: 1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
- Adjusts the Sentry configuration for edge and server configurations
- Increase sampling for edge and server configs
- Explicitly set `dsn` from environment variable

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
