### PR TITLE
fix: remove /hub/* pages from middleware

### DIFF
--- a/e2e/pizza-new.spec.ts
+++ b/e2e/pizza-new.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "@playwright/test";
+
+test("Redirects to /workspaces/new from /hub/insights/new (logged out user)", async ({ page }) => {
+  await page.goto("/hub/insights/new");
+
+  expect(page.url()).toContain("/workspaces/new");
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,7 +10,6 @@ import { getInsightWithWorkspace, getListWithWorkspace, getWorkspaceUrl } from "
 // prettier-ignore
 const pathsToMatch = [
   "/",
-  "/hub/:path*",
   "/feed/",
   "/user/notifications",
   "/user/settings",
@@ -116,12 +115,6 @@ export async function middleware(req: NextRequest) {
       const workspaceUrl = getWorkspaceUrl(req.cookies, req.url, data.personal_workspace_id);
 
       return NextResponse.redirect(`${workspaceUrl}`);
-    } else if (session?.user && req.nextUrl.pathname === "/hub/insights/new") {
-      const data = await loadSession(req, session?.access_token);
-
-      return NextResponse.redirect(
-        new URL(`/workspaces/${data.personal_workspace_id}/repository-insights/new`, req.url)
-      );
     } else {
       return res;
     }


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
- Removes /hub/* pages from being handled by middleware
- These are handled by redirects instead
- Adds E2E test to verify behavior

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
1. Go to /hub/insights/new as a non-authenticated user
2. Note page is redirected to /workspaces/new

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
