### PR TITLE
fix: now repo page OG images are corrext for production

### DIFF
--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -29,8 +29,10 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { owner } = await response.json();
 
   const range = (context.query.range ? Number(context.query.range) : 30) as Range;
-  const { NEXT_PUBLIC_BASE_URL = "http://localhost:3000" } = process.env;
-  const { href: ogImageUrl } = new URL(getRepositoryOgImage(repoData, range), NEXT_PUBLIC_BASE_URL);
+  const { href: ogImageUrl } = new URL(
+    getRepositoryOgImage(repoData, range),
+    process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
+  );
 
   return { props: { repoData, image: owner?.avatar_url || "", ogImageUrl } };
 }


### PR DESCRIPTION
## Description

Now, localhost is only used if `NEXT_PUBLIC_BASE_URL` isn't set for the repository page repo image.


## Related Tickets & Documents

Fixes #3180
Relates to #3117

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. Go to any repository page, e.g. https://deploy-preview-3179--oss-insights.netlify.app/s/open-sauced/app
2. Open the dev tools and expand the `<head>` section.
3. Notice the og:image and twitter:image have base URLs that are the deployment preview.

![CleanShot 2024-04-12 at 23 22 49](https://github.com/open-sauced/app/assets/833231/e89ad43d-e363-490b-aa34-5c36e7bba5f3)

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/l3V0H7bYv5Ml5TOfu/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
