### PR TITLE
fix: now suggestion prompts run immediately

### DIFF
--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -59,6 +59,21 @@ export default function StarSearchPage({ userId, bearerToken, ogImageUrl }: Star
   const [showSuggestions, setShowSuggestions] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  function addPromptInput(prompt: string) {
+    if (!inputRef.current?.form) {
+      return;
+    }
+
+    inputRef.current.value = prompt;
+    const { form } = inputRef.current;
+
+    if (typeof form.requestSubmit === "function") {
+      form.requestSubmit();
+    } else {
+      form.dispatchEvent(new Event("submit", { cancelable: true }));
+    }
+  }
+
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [chat, showSuggestions]);
@@ -139,12 +154,7 @@ export default function StarSearchPage({ userId, bearerToken, ogImageUrl }: Star
         return (
           <div className="flex flex-col text-center items-center gap-4 lg:pt-12 z-10">
             <Header />
-            <SuggestionBoxes
-              addPromptInput={(prompt) => {
-                setInput(prompt);
-                inputRef.current?.focus();
-              }}
-            />
+            <SuggestionBoxes addPromptInput={addPromptInput} />
           </div>
         );
       case "chat":
@@ -184,9 +194,8 @@ export default function StarSearchPage({ userId, bearerToken, ogImageUrl }: Star
                   <SuggestionBoxes
                     isHorizontal
                     addPromptInput={(prompt) => {
-                      setInput(prompt);
+                      addPromptInput(prompt);
                       setShowSuggestions(false);
-                      inputRef.current?.focus();
                     }}
                   />
                 </div>
@@ -224,12 +233,7 @@ export default function StarSearchPage({ userId, bearerToken, ogImageUrl }: Star
                     </button>
                   }
                 >
-                  <SuggestionBoxes
-                    addPromptInput={(prompt) => {
-                      setInput(prompt);
-                      inputRef.current?.focus();
-                    }}
-                  />
+                  <SuggestionBoxes addPromptInput={addPromptInput} />
                 </Drawer>
               ) : (
                 <>

--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -52,7 +52,6 @@ type StarSearchChat = {
 export default function StarSearchPage({ userId, bearerToken, ogImageUrl }: StarSearchPageProps) {
   const [starSearchState, setStarSearchState] = useState<"initial" | "chat">("initial");
   const [chat, setChat] = useState<StarSearchChat[]>([]);
-  const [input, setInput] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const [isRunning, setIsRunning] = useState(false);
   const isMobile = useMediaQuery("(max-width: 576px)");
@@ -248,13 +247,7 @@ export default function StarSearchPage({ userId, bearerToken, ogImageUrl }: Star
                   )}
                 </>
               ))}
-            <StarSearchInput
-              ref={inputRef}
-              input={input}
-              setInput={setInput}
-              isRunning={isRunning}
-              onSubmitPrompt={submitPrompt}
-            />
+            <StarSearchInput ref={inputRef} isRunning={isRunning} onSubmitPrompt={submitPrompt} />
           </div>
           <div className="absolute inset-x-0 top-0 z-0 h-[125px] w-full translate-y-[-100%] lg:translate-y-[-50%] rounded-full bg-gradient-to-r from-light-red-10 via-sauced-orange to-amber-400 opacity-40 blur-[40px]"></div>
         </div>
@@ -368,12 +361,10 @@ function Chatbox({ author, content, userId }: StarSearchChat & { userId?: number
 const StarSearchInput = forwardRef<
   HTMLInputElement,
   {
-    input: string;
-    setInput: (prompt: string) => void;
     isRunning: boolean;
     onSubmitPrompt: (prompt: string) => void;
   }
->(function StarSearchInput({ input, setInput, isRunning, onSubmitPrompt }, ref) {
+>(function StarSearchInput({ isRunning, onSubmitPrompt }, ref) {
   return (
     <section className="mx-0.5 lg:mx-auto w-full lg:max-w-3xl px-1 py-[3px] rounded-xl bg-gradient-to-r from-sauced-orange via-amber-400 to-sauced-orange">
       <form
@@ -391,8 +382,6 @@ const StarSearchInput = forwardRef<
           type="text"
           name="prompt"
           ref={ref}
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
           disabled={isRunning}
           placeholder="Ask a question"
           className="p-4 border bg-white focus:outline-none grow rounded-l-lg border-none"


### PR DESCRIPTION
## Description

Now suggestion prompts in StarSearch run immediately.

## Related Tickets & Documents

Fixes #3241

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-04-24 at 17 35 29](https://github.com/open-sauced/app/assets/833231/03f7b642-678e-4707-9648-5e4aaf1c35a3)

**After**

Note the double render is because of React strict mode during dev.

![CleanShot 2024-04-24 at 17 34 35](https://github.com/open-sauced/app/assets/833231/04dbfedb-68e3-4a65-b4c7-12903b5e24d7)

## Steps to QA

1. Go to `/star-search`
2. Click on a suggestion.
3. The suggestion populates the prompt input and StarSearch begins to respond immediately.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/2A75RyXVzzSI2bx4Gj/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
