### PR TITLE
fix: now StarSearch input is not covered by vertical suggestions on small screens

### DIFF
--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -18,6 +18,8 @@ import { useMediaQuery } from "lib/hooks/useMediaQuery";
 import SEO from "layouts/SEO/SEO";
 
 const HEIGHT_TO_TAKE_OFF_SCROLL_AREA = 340;
+const HEIGHT_TO_TAKE_OFF_SUGGESTIONS = 600;
+
 const SUGGESTIONS = [
   {
     title: "Get information on contributor activity",
@@ -173,7 +175,10 @@ export default function StarSearchPage({ userId, bearerToken, ogImageUrl }: Star
     switch (starSearchState) {
       case "initial":
         return (
-          <div className="flex flex-col text-center items-center gap-4 lg:pt-12 z-10">
+          <div
+            className="flex flex-col text-center items-center gap-4 lg:pt-12 mb-16"
+            // style={{ maxHeight: `calc(100vh - ${HEIGHT_TO_TAKE_OFF_SUGGESTIONS}px)` }}
+          >
             <Header />
             <SuggestionBoxes addPromptInput={addPromptInput} suggestions={SUGGESTIONS} />
           </div>


### PR DESCRIPTION
## Description

Now StarSearch input is not covered by vertical suggestions on small screens

## Related Tickets & Documents

Relates to #3258

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-04-25 at 19 50 49](https://github.com/open-sauced/app/assets/833231/ef763bb1-7be3-492c-b744-a85d615758ee)

**After**

![CleanShot 2024-04-25 at 19 50 09](https://github.com/open-sauced/app/assets/833231/82f19e25-1a48-4dcf-b16b-1b78ed03ffd8)

## Steps to QA

1. Go to StarSearch, `/star-search`
2. Resize the screen or use a smaller device.
3. Notice the vertical suggestions no longer cover the prompt input.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/3ohzdYJK1wAdPWVk88/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
