### PR TITLE
fix: now the page is cached varying on the day range

### DIFF
--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -55,6 +55,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
   // Cache for two hours
   context.res.setHeader("Netlify-CDN-Cache-Control", "public, max-age=0, stale-while-revalidate=7200");
+  context.res.setHeader("Netlify-Vary", "query=range");
 
   return { props: { repoData, ogImageUrl } };
 }

--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -56,6 +56,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   // Cache for two hours
   context.res.setHeader("Netlify-CDN-Cache-Control", "public, max-age=0, stale-while-revalidate=7200");
   context.res.setHeader("Netlify-Vary", "query=range");
+  context.res.setHeader("Cache-Tag", `repo-pages,repo-page-${repoData.id}`);
 
   return { props: { repoData, ogImageUrl } };
 }


### PR DESCRIPTION
## Description

Now cached repository pages vary on the range query parameter. I've also added a cache tag for repository pages and individual repository pages if we ever need to purge them.

Note the actual page loads the correct data for the given day range. It's only OG images that were affected.

## Related Tickets & Documents

Relates to #3278
Fixes #3311

## Mobile & Desktop Screenshots/Recordings

**Before**

30 day range

![CleanShot 2024-05-03 at 08 58 23](https://github.com/open-sauced/app/assets/833231/70eacc5e-36a7-4599-b086-c26152ab5a05)

90 day range

![CleanShot 2024-05-03 at 08 58 57](https://github.com/open-sauced/app/assets/833231/c430aa93-9f9c-40c9-b43f-29fa1fc30026)

**After**

30 day range

![CleanShot 2024-05-03 at 08 56 43](https://github.com/open-sauced/app/assets/833231/f965f273-b284-400c-868c-07a2bcba476d)

90 day range

![CleanShot 2024-05-03 at 08 57 46](https://github.com/open-sauced/app/assets/833231/51ae3b27-7614-47af-a6b5-3833cf05f3ba)

## Steps to QA

1. Go to https://deploy-preview-3310--oss-insights.netlify.app/s/open-sauced/app
2. Open the dev tools and look at the OG image URL. It's for the 30 day range. `https://deploy-preview-3310--oss-insights.netlify.app/og-images/repository/open-sauced/app/30?description=%F0%9F%8D%95+The+path+to+your+next+contribution.`
3. Go to https://deploy-preview-3310--oss-insights.netlify.app/s/open-sauced/app?range=90
4. Open the dev tools and look at the OG image URL. Notice the link is for 90 days and no longer the 30 day range, i.e. `https://deploy-preview-3310--oss-insights.netlify.app/og-images/repository/open-sauced/app/90?description=%F0%9F%8D%95+The+path+to+your+next+contribution.`


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/E20vdmmCxK82w2B7YN/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
