### PR TITLE
fixed Can keep typing in the bio field of user settings after 255 cha…

### DIFF
--- a/components/organisms/UserSettingsPage/user-settings-page.tsx
+++ b/components/organisms/UserSettingsPage/user-settings-page.tsx
@@ -283,20 +283,15 @@ const UserSettingsPage = ({ user }: UserSettingsPageProps) => {
                     name="bio"
                     className="w-full focus:outline-none placeholder:font-normal placeholder-slate-400 bg-inherit"
                     value={bio}
+                    maxLength={255}
                     onChange={(e) => setBio(e.target.value)}
                   ></textarea>
                 </div>
               </label>
 
-              {bio?.length > 255 ? (
-                <p aria-live="assertive" className="text-light-red-10 text-xs">
-                  Bio too long
-                </p>
-              ) : (
-                <p aria-live="polite" className="text-xs">
-                  {bio?.length}/255
-                </p>
-              )}
+              <p aria-live="polite" className="text-xs">
+                {bio?.length}/255
+              </p>
             </div>
             <TextInput
               className="bg-light-slate-4"


### PR DESCRIPTION
We currently display a message saying the bio is too long in the user settings, but we're not leveraging the native [maxLength](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength) HTML attribute to prevent someone from typing past the limit.

This PR removes the bug of having more words than the limit inside the bio
 - fix: A bug fix
## Related Tickets & Documents

Please use this format link issue numbers: Fixes #2615 
https://github.com/open-sauced/app/issues/2612


