### PR TITLE
fix : Can keep typing in the bio field of user settings after 255 characters 

### DIFF
--- a/components/organisms/UserSettingsPage/user-settings-page.tsx
+++ b/components/organisms/UserSettingsPage/user-settings-page.tsx
@@ -289,9 +289,15 @@ const UserSettingsPage = ({ user }: UserSettingsPageProps) => {
                 </div>
               </label>
 
-              <p aria-live="polite" className="text-xs">
-                {bio?.length}/255
-              </p>
+              {bio?.length == 255 ? (
+                <p aria-live="assertive" className="text-light-blue-10 text-xs">
+                  Bio is full cant contain more words
+                </p>
+              ) : (
+                <p aria-live="polite" className="text-xs">
+                  {bio?.length}/255
+                </p>
+              )}
             </div>
             <TextInput
               className="bg-light-slate-4"

--- a/components/organisms/UserSettingsPage/user-settings-page.tsx
+++ b/components/organisms/UserSettingsPage/user-settings-page.tsx
@@ -291,7 +291,7 @@ const UserSettingsPage = ({ user }: UserSettingsPageProps) => {
 
               {bio?.length == 255 ? (
                 <p aria-live="assertive" className="text-light-blue-10 text-xs">
-                  Bio is full cant contain more words
+                  Bio is full and cannot contain more words
                 </p>
               ) : (
                 <p aria-live="polite" className="text-xs">

--- a/components/organisms/UserSettingsPage/user-settings-page.tsx
+++ b/components/organisms/UserSettingsPage/user-settings-page.tsx
@@ -283,20 +283,15 @@ const UserSettingsPage = ({ user }: UserSettingsPageProps) => {
                     name="bio"
                     className="w-full focus:outline-none placeholder:font-normal placeholder-slate-400 bg-inherit"
                     value={bio}
+                    maxLength={255}
                     onChange={(e) => setBio(e.target.value)}
                   ></textarea>
                 </div>
               </label>
 
-              {bio?.length > 255 ? (
-                <p aria-live="assertive" className="text-light-red-10 text-xs">
-                  Bio too long
-                </p>
-              ) : (
-                <p aria-live="polite" className="text-xs">
-                  {bio?.length}/255
-                </p>
-              )}
+              <p aria-live="polite" className="text-xs">
+                {bio?.length}/255
+              </p>
             </div>
             <TextInput
               className="bg-light-slate-4"


### PR DESCRIPTION
## Description
We currently display a message saying the bio is too long in the user settings, but we're not leveraging the native [maxLength](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength) HTML attribute to prevent someone from typing past the limit.

While the user will add 255 words it will show a text which says Bio is full and now it cant contain more words

This PR  removes a bug 


## Related Tickets & Documents

Please use this format link issue numbers: Fixes #2615 
https://github.com/open-sauced/app/issues/2612


## Mobile & Desktop Screenshots/Recordings

![Screenshot from 2024-05-07 00-47-39](https://github.com/open-sauced/app/assets/103301856/ceaff275-78ff-4cf7-bb50-c1bfe2a19480)



## Steps to QA

1.Go to User settings 
2. Click in Bio
3. fill your bio



## [optional] What gif best describes this PR or how it makes you feel?

😊

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
