### PR TITLE
fix: Star-search md rendering renders spacing from LLM

### DIFF
--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -4,7 +4,7 @@ import { MdOutlineSubdirectoryArrowRight } from "react-icons/md";
 import { useEffect, useRef, useState } from "react";
 
 import Image from "next/image";
-import Markdown from "react-markdown";
+import ReactMarkdown from "react-markdown";
 import { TrashIcon } from "@heroicons/react/24/outline";
 import { BsArrowUpShort } from "react-icons/bs";
 import { ThumbsdownIcon, ThumbsupIcon, XCircleIcon } from "@primer/octicons-react";
@@ -170,13 +170,37 @@ export default function StarSearchPage({ userId, bearerToken, ogImageUrl }: Star
       values
         .filter((v) => v.startsWith("data:"))
         .forEach((v) => {
-          const matched = v.match(/data:\s(?<result>.+)/);
+          /*
+           * regex for capturing star-search stream SSEs:
+           * data:\s?(?<result>.*)
+           *
+           * The aim of this regex is to capture all characters coming from
+           * the star-search server side events while also preserving the
+           * empty "data:" frames that may come through (which are newlines).
+           *
+           * 'data:' - matches the "data:" characters explicitly.
+           * '\s'    - matches any whitespace that follows the data. In most cases, this is a single space ' '.
+           * '?'     - matches the previous whitespace token zero or one times. Aka, is optional.
+           *
+           * '(?<result>.*)' - optional named capture group "result".
+           *    ├────── '?'          - capture group is optional.
+           *    ├────── '<result>'   - capture group is named "result".
+           *    └────── '.*'         - matches any characters (including zero characters) after the "data:\s?" segment.
+           *                           this is in service of also capturing empty strings as newlines.
+           */
+
+          const matched = v.match(/data:\s?(?<result>.*)/);
+
           if (!matched || !matched.groups) {
             return;
           }
           const temp = [...chat];
           const changed = temp.at(temp.length - 1);
-          changed!.content += matched.groups.result;
+          if (matched.groups.result === "") {
+            changed!.content += "&nbsp; \n";
+          } else {
+            changed!.content += matched.groups.result;
+          }
           setChat(temp);
         });
     }
@@ -421,7 +445,7 @@ function Chatbox({ author, content, userId }: StarSearchChat & { userId?: number
       {renderAvatar()}
       <Card className="flex flex-col grow bg-white p-2 lg:p-4 w-full max-w-xl lg:max-w-5xl [&_a]:text-sauced-orange [&_a:hover]:underline">
         <h3 className="font-semibold text-sauced-orange">{author}</h3>
-        <Markdown>{content}</Markdown>
+        <ReactMarkdown>{content}</ReactMarkdown>
       </Card>
     </li>
   );

--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -4,7 +4,7 @@ import { MdOutlineSubdirectoryArrowRight } from "react-icons/md";
 import { useEffect, useRef, useState } from "react";
 
 import Image from "next/image";
-import ReactMarkdown from "react-markdown";
+import Markdown from "react-markdown";
 import { TrashIcon } from "@heroicons/react/24/outline";
 import { BsArrowUpShort } from "react-icons/bs";
 import { ThumbsdownIcon, ThumbsupIcon, XCircleIcon } from "@primer/octicons-react";
@@ -445,7 +445,7 @@ function Chatbox({ author, content, userId }: StarSearchChat & { userId?: number
       {renderAvatar()}
       <Card className="flex flex-col grow bg-white p-2 lg:p-4 w-full max-w-xl lg:max-w-5xl [&_a]:text-sauced-orange [&_a:hover]:underline">
         <h3 className="font-semibold text-sauced-orange">{author}</h3>
-        <ReactMarkdown>{content}</ReactMarkdown>
+        <Markdown>{content}</Markdown>
       </Card>
     </li>
   );


### PR DESCRIPTION
## Description

This adds 2 things primarily to the star-search markdown rendering:

1. Empty `data:` frames are counted as newlines from the model. This is done by making the `\s` spacing capture in the regex optional _and_ not forcing a capture in the `results` capture-group via `.+`: instead, we allow for any captures (including zero) through `.*`.
2. When we get an empty string in the capture group, adds a "&nbsp; \n" which _seems_ to be the way to get react-markdown to render some newlines/spacing correctly. I may be wrong on this, but it seems to work _okay_.

This also changes `Markdown` --> `ReactMarkdown`. This seems to be the way the library recommends rendering "safe" markdown that can't have code injected into it: https://www.npmjs.com/package/react-markdown/v/8.0.6

I also noticed what seems to be some improvements to the rendering of the markdown switching to `ReactMarkdown`.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings

Before:

<img width="1128" alt="Screenshot 2024-05-06 at 10 44 16 PM" src="https://github.com/open-sauced/app/assets/23109390/f620714c-437e-4029-bca1-899e35914414">

After:

<img width="1120" alt="Screenshot 2024-05-06 at 10 47 35 PM" src="https://github.com/open-sauced/app/assets/23109390/83619897-6070-4e08-af9d-05782461ec5b">

## Steps to QA

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [x] Tier 3
- [ ] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

