### PR TITLE
feat: implemented the substabs list component

### DIFF
--- a/components/TabList/tab-list.stories.tsx
+++ b/components/TabList/tab-list.stories.tsx
@@ -1,0 +1,28 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { SubTabsList } from "./tab-list";
+
+type Story = StoryObj<typeof SubTabsList>;
+
+const meta: Meta<typeof SubTabsList> = {
+  title: "Components/Shared/SubTabsList",
+  component: SubTabsList,
+  args: {
+    label: "Sub Tabs Example",
+    textSize: "regular",
+    tabList: [
+      { name: "Tab 1", path: "tab1" },
+      { name: "Tab 2", path: "tab2" },
+      { name: "Tab 3", path: "tab3" },
+    ],
+    selectedTab: "tab 1",
+  },
+};
+
+export default meta;
+
+export const Default: Story = {};
+export const SmallText: Story = {
+  args: {
+    textSize: "small",
+  },
+};

--- a/components/TabList/tab-list.tsx
+++ b/components/TabList/tab-list.tsx
@@ -1,26 +1,31 @@
 import React from "react";
 
+import Link from "next/link";
+import clsx from "clsx";
 import TabListItem from "./tab-list-item";
 
 type TabItem = {
   name: string;
   path: string;
-  numOf?: number;
 };
 
-interface NavProps {
+interface TabListProps {
   tabList: TabItem[];
   selectedTab: string;
   pageId?: string;
 }
 
-const TabList: React.FC<NavProps> = ({ tabList, pageId, selectedTab }) => {
+interface SubTabsListProps extends TabListProps {
+  label: string;
+  textSize?: "small" | "regular";
+}
+
+const TabList = ({ tabList, pageId, selectedTab }: TabListProps) => {
   return (
     <nav
       role="tablist"
       aria-orientation="horizontal"
       aria-label="Browse the tools"
-      tabIndex={0}
       className="tool-list-nav flex w-full overflow-x-auto overflow-y-hidden gap-2"
     >
       {tabList.map((tab, index) => (
@@ -39,6 +44,35 @@ const TabList: React.FC<NavProps> = ({ tabList, pageId, selectedTab }) => {
           <TabListItem tab={tab} pageLink={`${pageId ? `${pageId}/` : ""}${tab.path}`} selectedTab={selectedTab} />
         </div>
       ))}
+    </nav>
+  );
+};
+
+export const SubTabsList = ({ tabList, pageId, selectedTab, label, textSize }: SubTabsListProps) => {
+  return (
+    <nav
+      role="tablist"
+      aria-label={label}
+      className={clsx(
+        "flex items-center w-max overflow-x-auto overflow-y-hidden gap-2 bg-light-slate-3 p-1 rounded",
+        textSize === "small" && "text-sm"
+      )}
+    >
+      {tabList.map((tab, index) => {
+        const isSelected = selectedTab === tab.name.toLowerCase();
+
+        return (
+          <div
+            role="tab"
+            aria-selected={isSelected ? "true" : "false"}
+            data-state={isSelected ? "active" : "inactive"}
+            key={index}
+            className={clsx(isSelected && "bg-white shadow", "rounded py-1 px-2", !isSelected && "text-light-slate-11")}
+          >
+            <Link href={`${pageId ? `${pageId}/` : ""}${tab.path}`}>{tab.name}</Link>
+          </div>
+        );
+      })}
     </nav>
   );
 };


### PR DESCRIPTION
## Description

This PR introduces a sub-tabs list component.

## Related Tickets & Documents

Relates to #3322

## Mobile & Desktop Screenshots/Recordings

![CleanShot 2024-05-09 at 11 02 41](https://github.com/open-sauced/app/assets/833231/056d713b-dde3-40a7-9be0-b03880779923)

## Steps to QA

You can view the component in Storybook at https://deploy-preview-3352--design-insights.netlify.app/?path=/docs/components-shared-subtabslist--docs


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/7KwMyVvaNPXeU/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
