### PR TITLE
fix: temporarily returning for event: function_call in readable stream from StarSearch

### DIFF
--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -166,7 +166,14 @@ export default function StarSearchPage({ userId, bearerToken, ogImageUrl }: Star
         setIsRunning(false); // enables input
         return;
       }
+
+      // TODO: Remove this once https://github.com/open-sauced/app/issues/3372 is implemented.
+      if (value.startsWith("event: function_call")) {
+        continue;
+      }
+
       const values = value.split("\n");
+
       values
         .filter((v) => v.startsWith("data:"))
         .forEach((v) => {


### PR DESCRIPTION
## Description

Temporarily returning for `event: function_call` in readable stream from StarSearch until #3372.

## Related Tickets & Documents

Relates to #3372

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-05-14 at 15 16 04](https://github.com/open-sauced/app/assets/833231/b65239c3-3de2-4c8c-9164-4ae4ded0a223)

**After**

![CleanShot 2024-05-14 at 15 14 36](https://github.com/open-sauced/app/assets/833231/0f9c1fb7-34b2-41fc-8bac-78eb79458d5d)

## Steps to QA

1. Ask StarSearch a question.
2. No `event: function_call` text appears


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/QlJ4u0WkXcqT5Fv4HK/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
