### PR TITLE
fix: now on smaller screens a drawer opens for welcome to workspaces

### DIFF
--- a/components/Workspaces/WorkspaceWelcomeModal.tsx
+++ b/components/Workspaces/WorkspaceWelcomeModal.tsx
@@ -31,7 +31,7 @@ export default function WorkspaceWelcomeModal({ isOpen, onClose }: WorkspaceWelc
     </div>
   );
 
-  const isSmallScreen = useMediaQuery("(max-width: 768px)");
+  const isSmallScreen = useMediaQuery("(max-width: 640px)");
   const drawerButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {

--- a/components/Workspaces/WorkspaceWelcomeModal.tsx
+++ b/components/Workspaces/WorkspaceWelcomeModal.tsx
@@ -1,17 +1,77 @@
 import { RiExternalLinkLine } from "react-icons/ri";
+import { useEffect, useRef } from "react";
 import Button from "components/shared/Button/button";
 import Title from "components/atoms/Typography/title";
 import { Dialog, DialogTitle, DialogContent } from "components/molecules/Dialog/dialog";
 import Card from "components/atoms/Card/card";
 import Text from "components/atoms/Typography/text";
+import { useMediaQuery } from "lib/hooks/useMediaQuery";
+import { Drawer } from "components/shared/Drawer";
 
 interface WorkspaceWelcomeModalProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
+const TITLE = "Welcome to Workspaces";
 export default function WorkspaceWelcomeModal({ isOpen, onClose }: WorkspaceWelcomeModalProps) {
-  return (
+  const description = (
+    <Text>
+      Keep track of repositories and contributors easily with our new feature
+      <span className="font-semibold"> Workspaces!</span> If you&apos;ve used OpenSauced before, your insights and lists
+      are now part of your personal workspace.
+    </Text>
+  );
+
+  const content = (
+    <div className="grid gap-4 place-content-center">
+      <p className="font-medium text-light-orange-10">
+        Create a new workspace and explore open source like never before!
+      </p>
+    </div>
+  );
+
+  const isSmallScreen = useMediaQuery("(max-width: 768px)");
+  const drawerButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (isSmallScreen && isOpen && drawerButtonRef.current) {
+      drawerButtonRef.current.click();
+    }
+  }, [isSmallScreen, isOpen]);
+
+  return isSmallScreen ? (
+    <Drawer
+      title={TITLE}
+      description={
+        <div className="text-center flex flex-col items-center justify-between gap-4 !p-8">
+          <img
+            src="/assets/workspace_overview.png"
+            alt="Workspace screenshot from documentation"
+            className="border-2 border-light-orange-9 shadow-md rounded-lg mb-4"
+          />
+          {description}
+        </div>
+      }
+      trigger={<button ref={drawerButtonRef} />}
+      onClose={onClose}
+    >
+      <>
+        {content}
+        <div className="flex gap-4 place-content-center">
+          <Button
+            href="https://docs.opensauced.pizza/features/workspaces"
+            className="w-fit flex gap-4"
+            variant="primary"
+            target="_blank"
+          >
+            Learn more about Workspaces
+            <RiExternalLinkLine className="w-4 h-4" />
+          </Button>
+        </div>
+      </>
+    </Drawer>
+  ) : (
     <Dialog open={isOpen}>
       <DialogContent autoStyle={false} onEscapeKeyDown={onClose} onPointerDownOutside={onClose}>
         <Card className="sm:w-96 md:w-max max-w-xl text-center flex flex-col items-center justify-between gap-4 !p-8">
@@ -29,10 +89,8 @@ export default function WorkspaceWelcomeModal({ isOpen, onClose }: WorkspaceWelc
             <span className="font-semibold"> Workspaces!</span> If you&apos;ve used OpenSauced before, your insights and
             lists are now part of your personal workspace.
           </Text>
-          <p className="font-medium text-light-orange-10">
-            Create a new workspace and explore open source like never before!
-          </p>
-          <section className="flex gap-4">
+          {content}
+          <div className="flex gap-4 place-content-center">
             <Button
               href="https://docs.opensauced.pizza/features/workspaces"
               className="w-fit flex gap-4"
@@ -45,7 +103,7 @@ export default function WorkspaceWelcomeModal({ isOpen, onClose }: WorkspaceWelc
             <Button variant="outline" onClick={onClose}>
               Continue
             </Button>
-          </section>
+          </div>
         </Card>
       </DialogContent>
     </Dialog>

--- a/components/Workspaces/WorkspaceWelcomeModal.tsx
+++ b/components/Workspaces/WorkspaceWelcomeModal.tsx
@@ -24,11 +24,9 @@ export default function WorkspaceWelcomeModal({ isOpen, onClose }: WorkspaceWelc
   );
 
   const content = (
-    <div className="grid gap-4 place-content-center">
-      <p className="font-medium text-light-orange-10">
-        Create a new workspace and explore open source like never before!
-      </p>
-    </div>
+    <p className="font-medium text-light-orange-10 text-center">
+      Create a new workspace and explore open source like never before!
+    </p>
   );
 
   const isSmallScreen = useMediaQuery("(max-width: 640px)");

--- a/components/shared/Drawer.tsx
+++ b/components/shared/Drawer.tsx
@@ -16,6 +16,7 @@ interface DrawerProps {
   trigger: React.ReactNode;
   showCloseButton?: boolean;
   asChild?: boolean;
+  onClose?: () => void;
 }
 
 export const Drawer = ({
@@ -25,6 +26,7 @@ export const Drawer = ({
   showCloseButton = true,
   trigger,
   asChild = true,
+  onClose,
 }: DrawerProps) => {
   return (
     <InternalDrawer>
@@ -37,7 +39,9 @@ export const Drawer = ({
         <DrawerFooter className="">{children}</DrawerFooter>
         {showCloseButton ? (
           <div className="border-t flex items-center justify-center">
-            <DrawerClose className="p-2 text-light-orange-11 w-full outline-none">Close</DrawerClose>
+            <DrawerClose className="p-2 text-light-orange-11 w-full outline-none" onClick={onClose}>
+              Close
+            </DrawerClose>
           </div>
         ) : null}
       </DrawerContent>


### PR DESCRIPTION
## Description

Now on smaller screens a drawer instead of a modal when welcoming you to workspaces.

## Related Tickets & Documents

Fixes #3368

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-05-15 at 08 03 53](https://github.com/open-sauced/app/assets/833231/593ee6a3-c282-4f55-bdce-db7ee41e82bc)

**After**

![CleanShot 2024-05-15 at 08 20 41](https://github.com/open-sauced/app/assets/833231/d49956f2-6fb1-425a-ba18-e311bf4ac8b6)

_The smallest screen (width 320px) has the top cut off a bit, but I'm not going to worry about this right now. If someone is using that size device and reports it, I'll make adjustments._

## Steps to QA

1. Go to any workspace in the deploy preview on a smaller screen.
2. Notice a drawer component opens instead of a modal.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/WwB4oPyd6UxwfV9ZGU/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
