### PR TITLE
fix: fixed TS error and logic for gathering prompt response

### DIFF
--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -287,9 +287,15 @@ export default function StarSearchPage({ userId, bearerToken, ogImageUrl }: Star
       const { done, value } = await reader!.read();
       if (done) {
         setIsRunning(false); // enables input
+        const textChat = chat.filter((item) => typeof item.content === "string");
         registerPrompt({
           promptContent: prompt,
-          promptResponse: chat[chat.length - 1]?.content || "No response captured",
+          promptResponse:
+            chat
+              .slice(1)
+              // There can be multiple responses because of widgets, so we need to serialize the widget data
+              .map((c) => (typeof c.content === "string" ? c.content : JSON.stringify(c.content)))
+              .join("\n") || "No response captured",
         });
         return;
       }


### PR DESCRIPTION
## Description

Prompt response had widgets added to them in #3372. Prior to that the prompt response was always a string. Now we concatenate the responses as it may include widgets where we serialize the widget data.

## Related Tickets & Documents

Relates to #3405

## Mobile & Desktop Screenshots/Recordings

N/A


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
