### PR TITLE
fix: fix to avoid StarSearch UI breaking when long words are outputted

### DIFF
--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -632,7 +632,9 @@ function Chatbox({ message, userId }: { message: StarSearchChat; userId?: number
   let content;
 
   if (typeof message.content == "string") {
-    content = <Markdown>{message.content}</Markdown>;
+    // Breaking all words so that the rendered markdown doesn't overflow the container
+    // in certain cases where the content is a long string.
+    content = <Markdown className="break-all">{message.content}</Markdown>;
   } else {
     if (!componentRegistry.has(message.content.name)) {
       return null;


### PR DESCRIPTION
## Description

Fixes an issue in the StarSearch UI where chatboxes were expanding outside the viewport on small screens when long words were present in the prompt response.

## Related Tickets & Documents

Fixes #3421

## Mobile & Desktop Screenshots/Recordings

No screenshot atm but we debugged this together in our session @jpmcb @bdougie.

## Steps to QA

Hard to test at the moment but if you get a response

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
