### PR TITLE
fix: now sauced-orange colour defaults to 1 for opacity

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,7 +36,7 @@ module.exports = {
       },
       colors: {
         sauced: {
-          orange: "hsla(19, 100%, 50%, var(--tw-bg-opacity))",
+          orange: "hsla(19, 100%, 50%, var(--tw-bg-opacity, 1))",
           light: "hsl(24, 100%, 95%)",
         },
         gradient: {


### PR DESCRIPTION
## Description

Fixes a change made in #3422 where the usage of the `text-sauced-orange` or `bg-sauced-orange` defaulted to an opacity of 0. Now the default value is an opacity of 1.

## Related Tickets & Documents

Fixes #3436

## Mobile & Desktop Screenshots/Recordings

**Before**

![image](https://github.com/open-sauced/app/assets/833231/f2cafa0c-4335-4025-91c1-6fcf758e83af)

**After**

![CleanShot 2024-05-21 at 14 43 31](https://github.com/open-sauced/app/assets/833231/8c3dd65b-8ab7-467c-8c5e-ceb0add15908)

## Steps to QA

1. Go to a workspace page.
2. Notice


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/CANpaFjOx3WHJk0yY6/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
