### PR TITLE
fix: now StarSearch prompt/response area no longer scrolls when opening/closing suggestions

### DIFF
--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -243,7 +243,7 @@ export default function StarSearchPage({ userId, ogImageUrl }: StarSearchPagePro
 
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [chat, showSuggestions]);
+  }, [chat]);
 
   const submitPrompt = async (prompt: string) => {
     if (!bearerToken) {


### PR DESCRIPTION
## Description

Now the prompt/response area of StarSearch no longer scrolls when opening or closing the suggestions carousel (or drawer on smaller screens).

## Related Tickets & Documents

Fixes #3447

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-05-22 at 09 11 36](https://github.com/open-sauced/app/assets/833231/dfcaafde-20c5-46cd-b9ce-b0bc3904f0da)

**After**

![CleanShot 2024-05-22 at 09 17 24](https://github.com/open-sauced/app/assets/833231/2f0dba55-306c-41d4-a780-7a93b2817744)

## Steps to QA

1. Go to StarSearch, `/star-search`
2. Click on a suggested prompt.
3. A response is returned and scrolls to the bottom of the last response.
4. Scroll up in the prompt/response area.
5. Open the suggestions carousel (or drawer on smaller screens)
6. The prompt/response are no longer scrolls.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/4xWGyVKoXqg2eVCiq9/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
