### PR TITLE
fix: now StarSearch widgets have a max width of 440px and are centered in the card

### DIFF
--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -159,7 +159,11 @@ function StarSearchWidget({ widgetDefinition }: { widgetDefinition: WidgetDefini
       throw new Error(`Component ${widgetDefinition.name} not found in registry`);
     }
 
-    return componentToRender;
+    return (
+      <div className="w-full lg:w-1/2 mx-auto pt-2" style={{ maxWidth: "440px" }}>
+        {componentToRender}
+      </div>
+    );
   } catch (error: unknown) {
     Sentry.captureException(
       new Error(


### PR DESCRIPTION
## Description

Now StarSearch widgets have a max width of 440px and are centered in the StarSearch response card.

## Related Tickets & Documents

Fixes #3452

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-05-22 at 15 53 43](https://github.com/open-sauced/app/assets/833231/b5fb3b8d-2d18-49fe-b1dd-4f75072e0443)

**After**

![CleanShot 2024-05-22 at 15 49 08](https://github.com/open-sauced/app/assets/833231/be8841c9-692c-4ec7-95fe-bf9a7d0b0e84)

## Steps to QA

1. Go to StarSearch
2. Ask about the lotto factor for a project
3. Resize the screen and notice on larger screens the lotto factor widget is centered and no larger than 440px.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/2sXfuFtnYqmFl3lvUi/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
