### PR TITLE
fix: now StarSearch suggestion boxes have uniform widths

### DIFF
--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -701,7 +701,7 @@ function SuggestionBoxes({
           aria-labelledby={`prompt-label-${i}`}
           aria-describedby={`prompt-description-${i}`}
         >
-          <Card className="w-fit h-fit shadow-md border-none text-start !p-6 text-slate-600">
+          <Card className="w-full h-fit shadow-md border-none text-start !p-6 text-slate-600">
             <span id={`prompt-label-${i}`} className="text-sm lg:text-base font-semibold">
               {suggestion.title}
             </span>

--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -701,7 +701,7 @@ function SuggestionBoxes({
           aria-labelledby={`prompt-label-${i}`}
           aria-describedby={`prompt-description-${i}`}
         >
-          <Card className="w-full h-fit shadow-md border-none text-start !p-6 text-slate-600">
+          <Card className="w-full h-full shadow-md border-none text-start !p-6 text-slate-600">
             <span id={`prompt-label-${i}`} className="text-sm lg:text-base font-semibold">
               {suggestion.title}
             </span>


### PR DESCRIPTION
## Description

Now in all screen sizes, suggestion boxes have uniform widths.

In the case of Safari they also have uniform heights when in grid view on larger screens.

## Related Tickets & Documents

Fixes #3470

## Mobile & Desktop Screenshots/Recordings

**Before**

StarSearch suggestion promps do not have uniform widths.

Larger Screens

![CleanShot 2024-05-23 at 21 26 46@2x](https://github.com/open-sauced/app/assets/833231/0a353a37-c81f-40ca-a6ef-2ffb5d745739)

**Safari Only for grid view of suggestions**

![CleanShot 2024-05-23 at 21 41 09@2x](https://github.com/open-sauced/app/assets/833231/5656b076-4506-4d17-97cf-f2cd71cb9003)

**Smaller Screens**

![CleanShot 2024-05-23 at 21 26 57@2x](https://github.com/open-sauced/app/assets/833231/2d1bd0f3-5eb6-4556-8417-c3a49d085ba7)

**After**

StarSearch suggestion promps do not have uniform widths.

Larger Screens

![CleanShot 2024-05-23 at 21 25 58@2x](https://github.com/open-sauced/app/assets/833231/85d5aa44-2475-4e39-82a6-31c3119281fe)

**Safari Only for grid view of suggestions**

![CleanShot 2024-05-23 at 21 43 04@2x](https://github.com/open-sauced/app/assets/833231/a59028a3-3258-4524-9aa5-54d10b5a63b2)

**Smaller Screens**

![CleanShot 2024-05-23 at 21 27 15@2x](https://github.com/open-sauced/app/assets/833231/2e8727f5-8da8-4db2-91d7-8807fc2f5baf)

## Steps to QA
1. Go to `/star-search`
2. Resize the window to a medium breakpoint
3. Notice the suggestion boxes are stacked and uniform.
4. Do the same for a small screen where the drawer component opens.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/oYapDjZA6bnrQAwbi6/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
