### PR TITLE
fix: now search input is no longer squised on non-macOS devices

### DIFF
--- a/components/organisms/SearchDialog/search-dialog.tsx
+++ b/components/organisms/SearchDialog/search-dialog.tsx
@@ -166,9 +166,9 @@ const SearchDialog = () => {
             <SearchInfo />
           ) : isSearchError && !isSearching && (repoDataError || repoData.length === 0) ? (
             <Text className="block w-full py-1 px-4 text-sauced-orange !font-normal leading-6">
-                <HiOutlineExclamation className="text-sauced-orange inline-flex mr-2.5" fontSize={20} />
-                We couldn&apos;t find any users or repositories with that name
-            </Text>            
+              <HiOutlineExclamation className="text-sauced-orange inline-flex mr-2.5" fontSize={20} />
+              We couldn&apos;t find any users or repositories with that name
+            </Text>
           ) : (
             <>
               <section className="flex flex-col w-full">{renderUserSearchState()}</section>
@@ -200,7 +200,9 @@ const SearchDialogTrigger = () => {
   return (
     <>
       <div
-        className="hidden sm:flex justify-between p-1 pl-3 h-fit w-56 ml-auto bg-white border rounded-lg ring-light-slate-6 relative overflow-hidden"
+        className={`hidden sm:flex justify-between p-1 pl-3 h-fit ${
+          isMac ? "w-56" : "w-64"
+        } ml-auto bg-white border rounded-lg ring-light-slate-6 relative overflow-hidden`}
         onClick={() => setOpenSearch(true)}
       >
         <div className="flex items-center">


### PR DESCRIPTION
## Description

Used ternary operator to switch between w-56 and w-64, did not use w-72 as the header logo gets very small when approaching sm breakpoint.

## Related Tickets & Documents
Fixes #3481

## Mobile & Desktop Screenshots/Recordings

**Before**

**Non-macOS**
![image](https://github.com/open-sauced/app/assets/833231/fd32b631-6483-4168-bac6-c44f87b511b1)

**macOS**

![image](https://github.com/open-sauced/app/assets/110264527/33c6c83b-aa1d-47aa-b840-d5d571169102)

**After**

**Non-macOS**
![image](https://github.com/open-sauced/app/assets/110264527/3b1cbe9c-7568-4127-ac22-59cd5f14af27)

**macOS**
![image](https://github.com/open-sauced/app/assets/110264527/33c6c83b-aa1d-47aa-b840-d5d571169102)



## Steps to QA
1. Visit the main page from a mac machine.
2. Visit the main page from a windows machine.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
