### PR TITLE
fix: Use the "repos" query param in top-project-contributions-by-contributor

### DIFF
--- a/lib/hooks/api/useContributorsByProject.ts
+++ b/lib/hooks/api/useContributorsByProject.ts
@@ -8,7 +8,7 @@ export const useContributorsByProject = (listId: string, range = 30, repos?: str
   const query = new URLSearchParams();
 
   if (repoName) {
-    query.set("repo_name", `${repoName}`);
+    query.set("repos", `${repoName}`);
   }
 
   if (repos && repos.length > 0) {


### PR DESCRIPTION
## Description

This fixes a change to the DTO in the API for the `v2/lists/{id}/stats/top-project-contributions-by-contributor` endpoint. We should use the `repos` string (which can take 1 repo name, or many)

## Steps to QA

1. Run API locally (with corresponding changes in the API)
2. Run app locally
3. go to a user list
4. User list works as expected

(note: `useContributorsByProject` doesn't actually look to be used anywhere so this is more or less a no-op change)

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcjUxZDJzNGVjanlvN2EzdWw0NGY3ajh4MXRyeHNuODh3MWJmN3hoYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/y5W98cY6OCudO/giphy.gif)