### PR TITLE
fix: set `/star-search` user avatar after logging in

### DIFF
--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -1,7 +1,7 @@
 import { GetServerSidePropsContext } from "next";
 import { createPagesServerClient } from "@supabase/auth-helpers-nextjs";
 import { MdOutlineSubdirectoryArrowRight } from "react-icons/md";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 
 import Image from "next/image";
 import Markdown from "react-markdown";
@@ -29,6 +29,7 @@ import { StarSearchLoader } from "components/StarSearch/StarSearchLoader";
 import StarSearchLoginModal from "components/StarSearch/LoginModal";
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
 import AvatarHoverCard from "components/atoms/Avatar/avatar-hover-card";
+import useSession from "lib/hooks/useSession";
 
 export interface WidgetDefinition {
   name: string;
@@ -178,7 +179,7 @@ function StarSearchWidget({ widgetDefinition }: { widgetDefinition: WidgetDefini
   );
 }
 
-export default function StarSearchPage({ userId, ogImageUrl }: StarSearchPageProps) {
+export default function StarSearchPage({ userId: initialUserId, ogImageUrl }: StarSearchPageProps) {
   const [starSearchState, setStarSearchState] = useState<"initial" | "chat">("initial");
   const [chat, setChat] = useState<StarSearchChat[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -189,7 +190,9 @@ export default function StarSearchPage({ userId, ogImageUrl }: StarSearchPagePro
   const scrollRef = useRef<HTMLDivElement>(null);
   const { feedback, prompt } = useStarSearchFeedback();
   const { toast } = useToast();
+  const { session } = useSession(true);
   const { sessionToken: bearerToken } = useSupabaseAuth();
+  const userId = useMemo(() => (session ? session.id : initialUserId), [session]);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
 
   function registerPrompt(promptInput: StarSearchPromptAnalytic) {

--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -173,7 +173,6 @@ export default function StarSearchPage({ ogImageUrl }: { ogImageUrl: string }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [isRunning, setIsRunning] = useState(false);
   const isMobile = useMediaQuery("(max-width: 768px)");
-  const [showSuggestions, setShowSuggestions] = useState(false);
   const [ranOnce, setRanOnce] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const { feedback, prompt } = useStarSearchFeedback();
@@ -182,6 +181,7 @@ export default function StarSearchPage({ ogImageUrl }: { ogImageUrl: string }) {
   const userId = session ? session.id : undefined;
   const { sessionToken: bearerToken } = useSupabaseAuth();
   const [loginModalOpen, setLoginModalOpen] = useState(false);
+  const [showSuggestions, setShowSuggestions] = useState(false);
 
   function registerPrompt(promptInput: StarSearchPromptAnalytic) {
     prompt({

--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -1,7 +1,6 @@
 import { GetServerSidePropsContext } from "next";
-import { createPagesServerClient } from "@supabase/auth-helpers-nextjs";
 import { MdOutlineSubdirectoryArrowRight } from "react-icons/md";
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 
 import Image from "next/image";
 import Markdown from "react-markdown";
@@ -122,12 +121,6 @@ async function updateComponentRegistry(name: string) {
 }
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
-  const supabase = createPagesServerClient(context);
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  const userId = Number(session?.user.user_metadata.sub);
   const searchParams = new URLSearchParams();
 
   if (context.query.prompt) {
@@ -139,13 +132,8 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
   )}`;
 
-  return { props: { userId, ogImageUrl } };
+  return { props: { ogImageUrl } };
 }
-
-type StarSearchPageProps = {
-  userId: number;
-  ogImageUrl: string;
-};
 
 type StarSearchChat = { author: "You"; content: string } | { author: "StarSearch"; content: string | WidgetDefinition };
 
@@ -179,7 +167,7 @@ function StarSearchWidget({ widgetDefinition }: { widgetDefinition: WidgetDefini
   );
 }
 
-export default function StarSearchPage({ userId: initialUserId, ogImageUrl }: StarSearchPageProps) {
+export default function StarSearchPage({ ogImageUrl }: { ogImageUrl: string }) {
   const [starSearchState, setStarSearchState] = useState<"initial" | "chat">("initial");
   const [chat, setChat] = useState<StarSearchChat[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -191,8 +179,8 @@ export default function StarSearchPage({ userId: initialUserId, ogImageUrl }: St
   const { feedback, prompt } = useStarSearchFeedback();
   const { toast } = useToast();
   const { session } = useSession(true);
+  const userId = session ? session.id : "";
   const { sessionToken: bearerToken } = useSupabaseAuth();
-  const userId = useMemo(() => (session ? session.id : initialUserId), [session]);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
 
   function registerPrompt(promptInput: StarSearchPromptAnalytic) {

--- a/pages/star-search/index.tsx
+++ b/pages/star-search/index.tsx
@@ -179,7 +179,7 @@ export default function StarSearchPage({ ogImageUrl }: { ogImageUrl: string }) {
   const { feedback, prompt } = useStarSearchFeedback();
   const { toast } = useToast();
   const { session } = useSession(true);
-  const userId = session ? session.id : "";
+  const userId = session ? session.id : undefined;
   const { sessionToken: bearerToken } = useSupabaseAuth();
   const [loginModalOpen, setLoginModalOpen] = useState(false);
 


### PR DESCRIPTION
## Description

Added a `useMemo` to set the user ID based on the session. This fixes the issue where it doesn't render any image if the user starts logged out in the StarSearch page then logs in when prompted.
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents

Closes #3523 
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

https://github.com/open-sauced/app/assets/20603494/dffdf510-951e-4f78-a045-0161fe8893d9


<!-- Visual changes require screenshots -->


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
