### PR TITLE
fix: fixed contributor confidence percentage text alignment

### DIFF
--- a/components/Repositories/ContributorConfidenceChart.tsx
+++ b/components/Repositories/ContributorConfidenceChart.tsx
@@ -42,14 +42,14 @@ export default function ContributorConfidenceChart({
 
   return (
     <Card className={`${className ?? ""} flex flex-col gap-4 w-full h-fit items-center py-8`}>
-      <header className="flex w-full justify-between items-center px-4">
-        <div className="flex gap-2 items-center">
+      <header className="flex items-center justify-between w-full px-4">
+        <div className="flex items-center gap-2">
           <FaUserPlus className="text-xl" />
           <h3 className="text-sm font-semibold xl:text-lg text-slate-800">Contributor Confidence</h3>
         </div>
         <a
           href="https://opensauced.pizza/docs"
-          className="text-sauced-orange text-xs xl:text-sm font-semibold hover:underline"
+          className="text-xs font-semibold text-sauced-orange xl:text-sm hover:underline"
         >
           Learn More
         </a>
@@ -58,7 +58,7 @@ export default function ContributorConfidenceChart({
       {!isError && (isLoading || !contributorConfidence) ? (
         <SkeletonWrapper width={300} height={100} />
       ) : (
-        <section className="flex lg:flex-col xl:flex-row gap-2 justify-between w-full h-fit max-h-24 lg:max-h-full xl:max-h-24">
+        <section className="flex justify-between w-full gap-2 lg:flex-col xl:flex-row h-fit max-h-24 lg:max-h-full xl:max-h-24">
           <div className="w-full !max-w-[14rem] lg:max-w-full lg:mx-auto h-full lg:max-h-24 xl:h-full">
             <ResponsiveContainer width="100%" height={150}>
               <PieChart>
@@ -68,15 +68,15 @@ export default function ContributorConfidenceChart({
                   ))}
                   <Label
                     value={`${percentage}%`}
-                    position="center"
-                    className="fill-black text-base xl:text-xl font-semibold"
+                    position="centerBottom"
+                    className="text-base font-semibold fill-black xl:text-xl"
                   />
                 </Pie>
               </PieChart>
             </ResponsiveContainer>
           </div>
           <section className="flex flex-col gap-1 lg:text-center xl:text-start">
-            <h3 className="font-medium text-base lg:text-sm text-slate-700">This project {projectStatus}</h3>
+            <h3 className="text-base font-medium lg:text-sm text-slate-700">This project {projectStatus}</h3>
             <p className="text-base lg:text-sm text-slate-600">
               {projectDescription} stargazers and forkers come back later on to a meaningful contribution.
             </p>


### PR DESCRIPTION
## Description

Fixes the alignment of gauge and percentage text for the contributor confidence chart.

## Related Tickets & Documents

Relates to #3558

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-06-12 at 17 09 25](https://github.com/open-sauced/app/assets/833231/58383cec-d4c0-4337-9e52-767c0636058b)

**After**

![CleanShot 2024-06-12 at 17 08 50](https://github.com/open-sauced/app/assets/833231/a6db6fb8-e79f-4d02-b5f0-d819827155fc)


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [ ] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
