### PR TITLE
test: fixed failing test for StarSearch share prompt

### DIFF
--- a/e2e/star-search.spec.ts
+++ b/e2e/star-search.spec.ts
@@ -148,17 +148,13 @@ test("StarSearch shared prompt (Logged Out Flow)", async ({ page, browserName })
   await expect(shareToTwitterMenuItem).toBeVisible();
   await expect(shareToTwitterMenuItem.locator("a")).toHaveAttribute(
     "href",
-    `https://twitter.com/intent/tweet?text=Here%27s+my+StarSearch+prompt%21%0A%0ATry+it+out+for+yourself.+%23StarSearch&url=${encodeURIComponent(
-      BASE_URL
-    )}%2Fstar-search%3Fprompt%3DWho%2Bare%2Bthe%2Bmost%2Bprevalent%2Bcontributors%2Bto%2Bthe%2BTypeScript%2Becosystem%253F`
+    `https://twitter.com/intent/tweet?text=Here%27s+my+StarSearch+prompt%21%0A%0ATry+it+out+for+yourself.+%23StarSearch&url=https%3A%2F%2Fdub.sh%2Fte9DaAI`
   );
 
   await expect(shareToLinkedInMenuItem).toBeVisible();
   await expect(shareToLinkedInMenuItem.locator("a")).toHaveAttribute(
     "href",
-    `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
-      BASE_URL
-    )}%2Fstar-search%3Fprompt%3DWho%2Bare%2Bthe%2Bmost%2Bprevalent%2Bcontributors%2Bto%2Bthe%2BTypeScript%2Becosystem%253F`
+    `https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fdub.sh%2Fte9DaAI`
   );
   await expect(copyLinkMenuItem).toBeVisible();
 
@@ -168,9 +164,7 @@ test("StarSearch shared prompt (Logged Out Flow)", async ({ page, browserName })
   } else {
     // Ensure link was copied correctly
     await copyLinkMenuItem.click();
-    await expect(await page.evaluate("navigator.clipboard.readText()")).toEqual(
-      `${BASE_URL}/star-search?prompt=Who+are+the+most+prevalent+contributors+to+the+TypeScript+ecosystem%3F`
-    );
+    await expect(await page.evaluate("navigator.clipboard.readText()")).toEqual("https://dub.sh/te9DaAI");
   }
 
   await expect(sharePopupMenuTrigger).not.toHaveAttribute("aria-expanded");


### PR DESCRIPTION
## Description

Fixes a failing test. The URL for the shared prompt is now a dub.co short link.

From @brandonroberts: Its probably because Dub was getting to the free account limit (25 links), then it stops creating short links. If it fails, it just returns the copied URL. I nuked a bunch of the old ones, and now it doesn't create duplicates anymore.


## Related Tickets & Documents

Relates to #3325

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
