### PR TITLE
fix: now the title of a thread is set to the initial prompt of a StarSearch conversation

### DIFF
--- a/components/StarSearch/StarSearchChat.tsx
+++ b/components/StarSearch/StarSearchChat.tsx
@@ -455,15 +455,30 @@ export function StarSearchChat({
 
       const payload = await starSearchThreadResponse.json();
       id = payload.id;
-      setChatId(id);
-    }
 
-    try {
-      parseSchema(UuidSchema, id);
-    } catch (error) {
-      captureException(new Error(`Failed to parse UUID for StarSearch. UUID: ${chatId}`, { cause: error }));
-      chatError(true);
-      return;
+      try {
+        parseSchema(UuidSchema, id);
+      } catch (error) {
+        captureException(new Error(`Failed to parse UUID for StarSearch. UUID: ${chatId}`, { cause: error }));
+        chatError(true);
+        return;
+      }
+
+      const updateStarSearchThreadTitle = await fetch(`${baseUrl}/star-search/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ title: prompt }),
+        headers: {
+          Accept: "*/*",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${bearerToken}`,
+        },
+      });
+
+      if (updateStarSearchThreadTitle.status !== 200) {
+        captureException(new Error(`Failed to update StarSearch thread title. UUID: ${id}`));
+      }
+
+      setChatId(id);
     }
 
     const response = await fetch(`${baseUrl}/star-search/${id}/stream`, {


### PR DESCRIPTION
## Description

Fixes an issue where StarSearch might not have updated the thread title with a summary of the initial StarSearch conversation.

Note that StarSearch will eventually update the title of the thread with the summary. This is a fix in the event that someone shares before that's happened.

## Related Tickets & Documents

Relatest to #3563

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-06-18 at 16 32 50@2x](https://github.com/open-sauced/app/assets/833231/600640be-0301-431a-a6ba-832f03d609ec)

**After**

![CleanShot 2024-06-18 at 16 30 49](https://github.com/open-sauced/app/assets/833231/b8848290-48d7-4e0d-afa3-0e94931470cf)


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
