### PR TITLE
fix: now widgets in StarSearch look good width wise when embedded

### DIFF
--- a/components/StarSearch/StarSearchWidget.tsx
+++ b/components/StarSearch/StarSearchWidget.tsx
@@ -35,7 +35,7 @@ export function StarSearchWidget({
   }
 
   return (
-    <div className="w-full pt-2 lg:w-1/2" style={{ maxWidth: "440px" }}>
+    <div className="w-full pt-2" style={{ maxWidth: "440px" }}>
       <Component {...widgetDefinition.arguments} />
     </div>
   );


### PR DESCRIPTION
## Description

Now on pages that embed StarSearch, e.g. workspaces, the Lotto Factor widget, or any other future widget will no longer be squished.

## Related Tickets & Documents

Fixes #3625

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-06-24 at 21 52 12](https://github.com/open-sauced/app/assets/833231/9753eeed-4fa3-4e0b-b85a-9ad854a5609c)

**After**

![CleanShot 2024-06-24 at 21 51 59](https://github.com/open-sauced/app/assets/833231/6165a228-95f8-4337-8e6e-07ccc7548494)

## Steps to QA

1. Go to any workspace
2. Open StarSearch by pressing the StarSearch button at the bottom right of the screen.
3. Ask the questions, "What is the lottery factor of some-org/some-repo?"
4. Notice the lottery factor chart is not squished.
5. Go to `/star-search` and ask the same question.
6. The lottery chart should look as it did before (max of 440px wide).


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/QKSXTlCRK0r1N2NnkV/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
