### PR TITLE
fix: now StarSearch compact header no longer cuts off StarSearch logo

### DIFF
--- a/components/StarSearch/StarSearchCompactHeader.tsx
+++ b/components/StarSearch/StarSearchCompactHeader.tsx
@@ -35,7 +35,7 @@ export const StarSearchCompactHeader = ({
   return (
     <>
       {view === "chat" ? (
-        <div className="flex items-center justify-between gap-2 [&_button]:text-slate-600 h-8 p-1 bg-slate-50">
+        <div className="flex items-center justify-between gap-2 [&_button]:text-slate-600 h-9 p-1 bg-slate-50">
           <div className="flex items-center gap-2">
             <button onClick={onBack} className={buttonHoverStyle}>
               <ArrowLeftIcon />


### PR DESCRIPTION
## Description

Now the StarSearch logo is no longer cutt off slightly when StarSearch is embedded somewhere, e.g. a workspace page.

## Related Tickets & Documents

Fixes #3629

## Mobile & Desktop Screenshots/Recordings

**Before**

![image](https://github.com/open-sauced/app/assets/833231/2277c8f0-5723-4869-809f-3bea1e97302d)

**After**

![image](https://github.com/open-sauced/app/assets/833231/f265735f-c0b8-4631-83eb-bc61c8b6c61c)

## Steps to QA

1. Go to a workspace page.
2. Click on the StarSearch button at the bottom right.
3. StarSearch opens.
4. Notice the logo is no longer cut off slightly.
5. 
## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/l4Ki01RIvdIQVFhqE/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
