### PR TITLE
feat: added the repo name as a link above the lottery factor chart

### DIFF
--- a/components/StarSearch/Widgets/LotteryFactorWidget.tsx
+++ b/components/StarSearch/Widgets/LotteryFactorWidget.tsx
@@ -15,7 +15,14 @@ const LotteryFactorWidget = ({ repoName }: LotteryFactorWidgetProps) => {
     throw error;
   }
 
-  return <LotteryFactorChart lotteryFactor={data} isLoading={isLoading} error={error} range={range} />;
+  return (
+    <div className="grid gap-2">
+      <a className="font-semibold" href={`/s/${repoName}`} style={{ color: "inherit" }} target="_blank">
+        {repoName}
+      </a>
+      <LotteryFactorChart lotteryFactor={data} isLoading={isLoading} error={error} range={range} />
+    </div>
+  );
 };
 
 export default LotteryFactorWidget;

--- a/components/StarSearch/Widgets/LotteryFactorWidget.tsx
+++ b/components/StarSearch/Widgets/LotteryFactorWidget.tsx
@@ -1,13 +1,32 @@
+import { useEffect, useState } from "react";
+import { captureException } from "@sentry/nextjs";
 import LotteryFactorChart from "components/Repositories/LotteryFactorChart";
 import { useRepositoryLottoFactor } from "lib/hooks/api/useRepositoryLottoFactor";
+import { shortenUrl } from "lib/utils/shorten-url";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
 
 interface LotteryFactorWidgetProps {
   repoName: string;
 }
 
 const LotteryFactorWidget = ({ repoName }: LotteryFactorWidgetProps) => {
+  const longUrl = new URL(`/s/${repoName}?utm=starsearch-workspaces`, BASE_URL).toString();
   const range = 30;
   const { data, error, isLoading } = useRepositoryLottoFactor({ repository: repoName.toLowerCase(), range });
+  const [shortUrl, setShortUrl] = useState(longUrl);
+
+  useEffect(() => {
+    if (repoName) {
+      shortenUrl(longUrl)
+        .then((url) => {
+          setShortUrl(url);
+        })
+        .catch(() => {
+          captureException(new Error(`Failed to shorten URL for ${repoName}`));
+        });
+    }
+  }, [repoName]);
 
   if (error) {
     // whether it's a 404 or any other error, we don't want to render the widget
@@ -17,7 +36,7 @@ const LotteryFactorWidget = ({ repoName }: LotteryFactorWidgetProps) => {
 
   return (
     <div className="grid gap-2">
-      <a className="font-semibold" href={`/s/${repoName}`} style={{ color: "inherit" }} target="_blank">
+      <a className="font-semibold" href={shortUrl} style={{ color: "inherit" }} target="_blank">
         {repoName}
       </a>
       <LotteryFactorChart lotteryFactor={data} isLoading={isLoading} error={error} range={range} />


### PR DESCRIPTION
## Description

Now there is a header that is a link above lottery factor widgets in StarSearch so they can be distinguished from one another when more than one repository lottery factor widget is rendered in StarSearch.

## Related Tickets & Documents

Closes #3631

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-06-25 at 14 19 11](https://github.com/open-sauced/app/assets/833231/d5837986-d246-4198-858b-e56e77131afb)

**After**

![CleanShot 2024-06-25 at 14 09 31](https://github.com/open-sauced/app/assets/833231/515ed581-89e4-4ff1-9cf8-fb5cacfddf5e)

## Steps to QA

1. Go to a workspace with multiple tracked repositories.
2. Ask the stock question, "Are there any repositories that have a very high lottery factor?"
3. It's non-deterministic, but more often than not, you will get multiple lottery factor widgets returned. 


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/26uXMnP8l9zkVrnhe/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
