### PR TITLE
feat: Remove deprecated v2/lists/:id/contributors endpoint

### DIFF
--- a/components/molecules/ListCard/list-card.tsx
+++ b/components/molecules/ListCard/list-card.tsx
@@ -18,7 +18,7 @@ interface ListCardProps {
   user: User | null;
 }
 const ListCard = ({ list, handleOnDeleteClick, workspaceId, user }: ListCardProps) => {
-  const { data: contributors, meta } = useFetchListContributors(list.id);
+  const { data: contributors, meta } = useFetchListContributors(workspaceId!, list.id);
 
   const contributorsAvatar: Contributor[] = contributors?.map((contributor) => ({
     host_login: contributor.login || contributor.username,

--- a/lib/hooks/api/useContributorList.ts
+++ b/lib/hooks/api/useContributorList.ts
@@ -10,6 +10,7 @@ export function convertToContributors(rawContributors: DBListContributor[] = [])
           username: contributor.username,
           updated_at: contributor.created_at,
           user_id: contributor.id,
+          oscr: contributor.oscr,
         };
       })
     : [];

--- a/lib/hooks/api/useContributorList.ts
+++ b/lib/hooks/api/useContributorList.ts
@@ -18,12 +18,14 @@ export function convertToContributors(rawContributors: DBListContributor[] = [])
 }
 
 export const useContributorsList = ({
+  workspaceId,
   listId,
   initialData,
   initialPage = 1,
   defaultLimit = 10,
   defaultRange = "30",
 }: {
+  workspaceId: string | undefined;
   listId: string | undefined;
   initialData?: {
     data: DbPRContributor[];
@@ -41,7 +43,7 @@ export const useContributorsList = ({
   query.append("range", defaultRange ?? "30");
 
   const { data, error, mutate } = useSWR<any>(
-    listId ? `lists/${listId}/contributors?${query}` : null,
+    listId ? (workspaceId ? `workspaces/${workspaceId}/userLists/${listId}/contributors?${query}` : null) : null,
     publicApiFetcher as Fetcher<PagedData<DBListContributor>, Error>,
     {
       fallbackData: initialData,

--- a/lib/hooks/useFetchAllListContributors.ts
+++ b/lib/hooks/useFetchAllListContributors.ts
@@ -9,6 +9,7 @@ interface PaginatedResponse {
 }
 
 type QueryObj = {
+  workspaceId: string;
   listId: string;
   location?: string;
   pr_velocity?: string;
@@ -42,7 +43,7 @@ const useFetchAllListContributors = (query: QueryObj, config?: SWRConfiguration,
     urlQuery.set("limit", `${limit}`);
   }
 
-  const baseEndpoint = `lists/${query.listId}/contributors`;
+  const baseEndpoint = `workspaces/${query.workspaceId}/userLists/${query.listId}/contributors`;
   const endpointString = `${baseEndpoint}?${urlQuery}`;
 
   const { data, error, mutate } = useSWR<PaginatedResponse, Error>(

--- a/lib/hooks/useList.ts
+++ b/lib/hooks/useList.ts
@@ -43,7 +43,7 @@ const useFetchAllLists = (range = 30, shouldFetch = true) => {
   };
 };
 
-const useFetchListContributors = (id: string, range = 30) => {
+const useFetchListContributors = (workspaceId: string, lsitId: string, range = 30) => {
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(10);
 
@@ -52,10 +52,10 @@ const useFetchListContributors = (id: string, range = 30) => {
   query.set("page", `${page}`);
   query.set("limit", `${limit}`);
   query.set("range", `${range}`);
-  const endpointString = `lists/${id}/contributors?${query.toString()}`;
+  const endpointString = `workspaces/${workspaceId}/userLists/${lsitId}/contributors?${query.toString()}`;
 
   const { data, error, mutate } = useSWR<PaginatedListContributorsResponse, Error>(
-    id ? endpointString : null,
+    lsitId ? endpointString : null,
     publicApiFetcher as Fetcher<PaginatedListContributorsResponse, Error>
   );
 

--- a/lib/hooks/useList.ts
+++ b/lib/hooks/useList.ts
@@ -43,7 +43,7 @@ const useFetchAllLists = (range = 30, shouldFetch = true) => {
   };
 };
 
-const useFetchListContributors = (workspaceId: string, lsitId: string, range = 30) => {
+const useFetchListContributors = (workspaceId: string, listId: string, range = 30) => {
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(10);
 
@@ -52,10 +52,10 @@ const useFetchListContributors = (workspaceId: string, lsitId: string, range = 3
   query.set("page", `${page}`);
   query.set("limit", `${limit}`);
   query.set("range", `${range}`);
-  const endpointString = `workspaces/${workspaceId}/userLists/${lsitId}/contributors?${query.toString()}`;
+  const endpointString = `workspaces/${workspaceId}/userLists/${listId}/contributors?${query.toString()}`;
 
   const { data, error, mutate } = useSWR<PaginatedListContributorsResponse, Error>(
-    lsitId ? endpointString : null,
+    listId ? endpointString : null,
     publicApiFetcher as Fetcher<PaginatedListContributorsResponse, Error>
   );
 

--- a/next-types.d.ts
+++ b/next-types.d.ts
@@ -133,6 +133,7 @@ interface DBListContributor {
   readonly public_repos: number;
   readonly receive_collaboration: boolean;
   readonly username: string;
+  readonly oscr: number;
 }
 
 interface DbRepoPREvents {

--- a/pages/workspaces/[workspaceId]/contributor-insights/[listId]/edit.tsx
+++ b/pages/workspaces/[workspaceId]/contributor-insights/[listId]/edit.tsx
@@ -81,7 +81,7 @@ export default function ContributorInsightEditPage({
 }: ContributorInsightEditPageProps) {
   const {
     data: { data: contributors },
-  } = useContributorsList({ listId: list?.id });
+  } = useContributorsList({ workspaceId, listId: list?.id });
   const initialTrackedContributors = new Map([
     ...contributors.map((contributor) => [contributor.author_login, true] as const),
   ]);

--- a/pages/workspaces/[workspaceId]/contributor-insights/[listId]/overview.tsx
+++ b/pages/workspaces/[workspaceId]/contributor-insights/[listId]/overview.tsx
@@ -104,6 +104,7 @@ const ListsOverview = ({
     setPage,
     data: { data: contributors, meta },
   } = useContributorsList({
+    workspaceId,
     listId: list?.id,
     defaultRange: range ? (range as string) : "30",
     defaultLimit: limit ? (limit as unknown as number) : 10,


### PR DESCRIPTION
## Description

Uses `v2/workspaces/:workspace-id/userLists/:list-id/contributors` endpoint in favor of the deprecated `v2/lists/:id/contributors` endpoint in the API

## Related Tickets & Documents

Related to #3627 

## Steps to QA

1. Run API locally
2. Run app locally
3. Go to a workspace user list - list is populated correctly


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4