### PR TITLE
fix: now a new StarSearch chat can be started if one was in progress

### DIFF
--- a/components/StarSearch/StarSearchChat.tsx
+++ b/components/StarSearch/StarSearchChat.tsx
@@ -107,6 +107,7 @@ export function StarSearchChat({
   const [shareLinkError, setShareLinkError] = useState(false);
 
   const onNewChat = () => {
+    setIsRunning(false);
     setChatId(null);
     setStarSearchState("initial");
     setChat([]);


### PR DESCRIPTION
## Description

Now `isRunning` is reset to `false` when starting a new conversation. This was preventing the stream conversation from beginning when a previous one was cancelled and a new conversation started.

## Related Tickets & Documents

Fixes #3636

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-06-25 at 21 25 35](https://github.com/open-sauced/app/assets/833231/192f027a-2443-4239-b8f0-4cb1c5b57de5)

**After**

![CleanShot 2024-06-25 at 21 26 04](https://github.com/open-sauced/app/assets/833231/d47df9e3-936a-4f66-acb2-6d61e5ec7184)

## Steps to QA

1. Go to any workspace and open StarSearch
2. Start a conversation
3. Cancel it by clicking the back button or new conversation buttons in the compact StarSearch header.
4. Start the new conversation.
5. Notice the new conversation streams in.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
