### PR TITLE
feat: now StarSearch conversation share link button has a loading state

### DIFF
--- a/components/StarSearch/ShareChatMenu.tsx
+++ b/components/StarSearch/ShareChatMenu.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "components/atoms/Dropdown/dropdown";
+import { Spinner } from "components/atoms/SpinLoader/spin-loader";
 
 interface ShareMenuProps {
   shareUrl: string | null | undefined;
@@ -19,6 +20,7 @@ interface ShareMenuProps {
 export function ShareChatMenu({ shareUrl, copyLinkHandler, createLink }: ShareMenuProps) {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [isCreatingLink, setIsCreatingLink] = useState(false);
 
   let twitterUrl = "https://twitter.com/intent/tweet";
   let linkedInUrl = "https://www.linkedin.com/sharing/share-offsite/";
@@ -44,13 +46,28 @@ export function ShareChatMenu({ shareUrl, copyLinkHandler, createLink }: ShareMe
         {createLink ? (
           <DropdownMenuItem className="pl-4 rounded-md">
             <button
-              className="flex items-center w-full gap-1"
+              className="flex items-center w-full gap-2"
               onClick={() => {
+                if (isCreatingLink) {
+                  return;
+                }
+
                 createLink();
+                setIsCreatingLink(true);
               }}
+              aria-disabled={isCreatingLink}
             >
-              <LinkIcon size={12} />
-              <span>Create Share Link</span>
+              {isCreatingLink ? (
+                <>
+                  <Spinner className="w-3 h-3 stroke-light-slate-12" />
+                  <span>Creating Share Link</span>
+                </>
+              ) : (
+                <>
+                  <LinkIcon size={12} />
+                  <span>Create Share Link</span>
+                </>
+              )}
             </button>
           </DropdownMenuItem>
         ) : (

--- a/components/StarSearch/ShareChatMenu.tsx
+++ b/components/StarSearch/ShareChatMenu.tsx
@@ -1,7 +1,7 @@
 import { HiOutlineShare } from "react-icons/hi";
 import { BsLink45Deg, BsTwitterX } from "react-icons/bs";
 import { FiLinkedin } from "react-icons/fi";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { LinkIcon } from "@primer/octicons-react";
 import {
   DropdownMenu,
@@ -15,12 +15,19 @@ interface ShareMenuProps {
   shareUrl: string | null | undefined;
   copyLinkHandler: (url: string) => Promise<void>;
   createLink?: () => void;
+  error: boolean;
 }
 
-export function ShareChatMenu({ shareUrl, copyLinkHandler, createLink }: ShareMenuProps) {
+export function ShareChatMenu({ shareUrl, copyLinkHandler, createLink, error }: ShareMenuProps) {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  const [isCreatingLink, setIsCreatingLink] = useState(false);
+  const [isCreatingLink, setIsCreatingLink] = useState(error);
+
+  useEffect(() => {
+    if (error) {
+      setIsCreatingLink(!error);
+    }
+  }, [error]);
 
   let twitterUrl = "https://twitter.com/intent/tweet";
   let linkedInUrl = "https://www.linkedin.com/sharing/share-offsite/";

--- a/components/StarSearch/StarSearchChat.tsx
+++ b/components/StarSearch/StarSearchChat.tsx
@@ -104,6 +104,7 @@ export function StarSearchChat({
   const [checkAuth, setCheckAuth] = useState(false);
   const [chatId, setChatId] = useState<string | null>(sharedChatId);
   const [view, setView] = useState<"prompt" | "chat">("prompt");
+  const [shareLinkError, setShareLinkError] = useState(false);
 
   const onNewChat = () => {
     setChatId(null);
@@ -624,6 +625,8 @@ export function StarSearchChat({
                           threadHistory?.is_publicly_viewable
                             ? undefined
                             : async () => {
+                                setShareLinkError(false);
+
                                 try {
                                   parseSchema(UuidSchema, chatId);
                                 } catch (error) {
@@ -657,6 +660,7 @@ export function StarSearchChat({
                                   // and gets the public_link and is_publicly_viewable property updates
                                   mutateThreadHistory(undefined, true);
                                 } else {
+                                  setShareLinkError(true);
                                   toast({
                                     description: "Failed to create a share link",
                                     variant: "danger",
@@ -672,6 +676,7 @@ export function StarSearchChat({
                             variant: "success",
                           });
                         }}
+                        error={shareLinkError}
                       />
                     </div>
                   ) : null}


### PR DESCRIPTION
## Description

Now the StarSearch conversation share link button has a loading state so that it does not appear broken when generating a shareable link to a conversation.

## Related Tickets & Documents

Fixes #3615

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-06-26 at 08 07 24](https://github.com/open-sauced/app/assets/833231/279d28ec-9923-4f14-80e6-adc4365d9619)

**After**

![CleanShot 2024-06-26 at 08 06 49](https://github.com/open-sauced/app/assets/833231/d4a41f3d-91e0-4113-b831-255ee4448200)

## Steps to QA

1. Create a StarSearch conversation from `/star-search`
2. Once the conversation completes, open the share menu just below the last message in the conversation.
3. Click Create share link.
4. Notice there is a loading state before the shareable link and CTAs to share to socials appear.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/uIJBFZoOaifHf52MER/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
