### PR TITLE
fix: now OSCR that is 0 gets rendered as a dash

### DIFF
--- a/components/Contributors/OscrPill.tsx
+++ b/components/Contributors/OscrPill.tsx
@@ -4,6 +4,10 @@ import Tooltip from "components/atoms/Tooltip/tooltip";
 export const OscrPill = ({ rating }: { rating: number }) => {
   const percentageRating = Math.floor(rating * 100);
 
+  if (percentageRating < 1) {
+    return null;
+  }
+
   return (
     <Tooltip direction="top" content="Open Source Contributor Rating (OSCR)">
       <Pill color="purple" size="small" text={`${percentageRating}`} />

--- a/components/molecules/ContributorListTableRow/contributor-list-table-row.tsx
+++ b/components/molecules/ContributorListTableRow/contributor-list-table-row.tsx
@@ -198,7 +198,7 @@ const ContributorListTableRow = ({
 
         {/* Column: OSCR */}
         <div className={clsx("flex-1 lg:max-w-[5rem] text-light-slate-11 justify-center   lg:flex ")}>
-          <div className="flex gap-x-3">{contributor.oscr ? <OscrPill rating={contributor.oscr} /> : "-"}</div>
+          <div className="flex gap-x-3">{contributor.oscr ? <OscrPill rating={contributor.oscr} /> ?? "-" : "-"}</div>
         </div>
 
         {/* Column Repositories */}


### PR DESCRIPTION
## Description

Now OSCR that are 0 or less are rendered as a dash in the contributors table and on mobile, it is not rendered at all.

## Related Tickets & Documents

Fixes #3661

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-07-02 at 09 59 28](https://github.com/open-sauced/app/assets/833231/cf3fb558-2cf2-41be-bb45-fa41a7046baf)

![CleanShot 2024-07-02 at 10 00 15](https://github.com/open-sauced/app/assets/833231/4c2954ce-4b30-4f80-a5a7-d6e4915e9ff6)

**After**

![CleanShot 2024-07-02 at 09 57 32](https://github.com/open-sauced/app/assets/833231/cb5f6014-1cf1-4873-81c1-687d58304430)

![CleanShot 2024-07-02 at 10 00 44](https://github.com/open-sauced/app/assets/833231/cd0c7953-8a92-4c2b-b2e6-0f6a7a9d77ef)

## Steps to QA

1. Go to any workspace that has a contributor insight
2. A little tricky to test potentially, but try and add someone who has an OSCR of zero.
3. Notice the rows with OSCR at 0 render a dash in the contributors table and on mobile, it's not rendered at all.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/l2JdYkTPVG9gRbvhK/giphy.gif"/>


<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->