### PR TITLE
fix: now workspace pages on smaller screens keep their layout in bounds

### DIFF
--- a/components/Workspaces/WorkspaceHeader.tsx
+++ b/components/Workspaces/WorkspaceHeader.tsx
@@ -11,9 +11,10 @@ import { writeToClipboard } from "lib/utils/write-to-clipboard";
 
 interface WorkspaceHeaderProps {
   workspace: Workspace;
+  children?: React.ReactNode;
 }
 
-export const WorkspaceHeader = ({ workspace }: WorkspaceHeaderProps) => {
+export const WorkspaceHeader = ({ workspace, children }: WorkspaceHeaderProps) => {
   const { toast } = useToast();
   const posthog = usePostHog();
   const { userId } = useSupabaseAuth();
@@ -44,7 +45,8 @@ export const WorkspaceHeader = ({ workspace }: WorkspaceHeaderProps) => {
         </span>
         <Pill className="font-medium" text={workspace.is_public ? "Public" : "Private"} />
       </h1>
-      <div className="flex gap-4">
+      <div className="flex gap-2 justify-end">
+        {children}
         <Button
           variant="outline"
           onClick={copyUrlToClipboard}

--- a/pages/workspaces/[workspaceId]/activity.tsx
+++ b/pages/workspaces/[workspaceId]/activity.tsx
@@ -153,7 +153,7 @@ const WorkspaceActivityPage = ({
                 selectedTab={"pull requests"}
                 pageId={`/workspaces/${workspace.id}`}
               />
-              <div className="flex justify-end items-center gap-4">
+              <div className="flex items-center justify-end gap-4 flex-wrap w-full mb-2">
                 <TrackedRepositoryFilter
                   options={filterOptions}
                   handleSelect={(selected: OptionKeys[]) => {

--- a/pages/workspaces/[workspaceId]/activity.tsx
+++ b/pages/workspaces/[workspaceId]/activity.tsx
@@ -142,18 +142,21 @@ const WorkspaceActivityPage = ({
             <WorkspacesTabList workspaceId={workspace.id} selectedTab={"activity"} />
           </div>
           <div className="mt-6 grid gap-6">
-            <div className="grid md:flex justify-between gap-2 md:gap-4">
-              <SubTabsList
-                label="Activity pages"
-                textSize="small"
-                tabList={[
-                  { name: "Pull Requests", path: "activity" },
-                  { name: "Issues", path: "issues" },
-                ]}
-                selectedTab={"pull requests"}
-                pageId={`/workspaces/${workspace.id}`}
-              />
-              <div className="flex items-center justify-end gap-4 flex-wrap w-full mb-2">
+            <div className="grid md:flex gap-2 md:gap-4 w-full items-center mb-2">
+              <div className="flex items-center justify-between w-full md:w-fit">
+                <SubTabsList
+                  label="Activity pages"
+                  textSize="small"
+                  tabList={[
+                    { name: "Pull Requests", path: "activity" },
+                    { name: "Issues", path: "issues" },
+                  ]}
+                  selectedTab={"pull requests"}
+                  pageId={`/workspaces/${workspace.id}`}
+                />
+                {isMobile ? <DayRangePicker /> : null}
+              </div>
+              <div className="flex items-center justify-end gap-2 flex-wrap w-full">
                 <TrackedRepositoryFilter
                   options={filterOptions}
                   handleSelect={(selected: OptionKeys[]) => {
@@ -161,7 +164,7 @@ const WorkspaceActivityPage = ({
                     setQueryParams({ page: "1" });
                   }}
                 />
-                <DayRangePicker />
+                {isMobile ? null : <DayRangePicker />}
                 <LimitPicker />
               </div>
             </div>

--- a/pages/workspaces/[workspaceId]/index.tsx
+++ b/pages/workspaces/[workspaceId]/index.tsx
@@ -170,23 +170,25 @@ const WorkspaceDashboard = ({
         }
       >
         <div className="px-4 py-8 lg:px-16 lg:py-12">
-          <WorkspaceHeader workspace={workspace} />
+          <WorkspaceHeader workspace={workspace}>
+            <Button
+              variant="outline"
+              className="my-auto gap-2 items-center shrink-0"
+              onClick={() => {
+                if (overLimit) {
+                  setIsInsightUpgradeModalOpen(true);
+                  return;
+                }
+
+                router.push(`/workspaces/${workspace.id}/settings#load-wizard`);
+              }}
+            >
+              Add repositories
+            </Button>
+          </WorkspaceHeader>
           <div className="grid gap-4 pt-3 border-b sm:flex">
             <WorkspacesTabList workspaceId={workspace.id} selectedTab={"repositories"} />
-            <div className="flex items-center justify-end gap-4">
-              <Button
-                variant="outline"
-                onClick={() => {
-                  if (overLimit) {
-                    setIsInsightUpgradeModalOpen(true);
-                    return;
-                  }
-
-                  router.push(`/workspaces/${workspace.id}/settings#load-wizard`);
-                }}
-              >
-                Add repositories
-              </Button>
+            <div className="flex items-center justify-end gap-4 flex-wrap w-full mb-2">
               <DayRangePicker />
               <TrackedRepositoryFilter
                 options={filterOptions}

--- a/pages/workspaces/[workspaceId]/issues.tsx
+++ b/pages/workspaces/[workspaceId]/issues.tsx
@@ -20,6 +20,7 @@ import WorkspaceBanner from "components/Workspaces/WorkspaceBanner";
 import { OrderIssuesBy, useGetWorkspaceIssues } from "lib/hooks/api/useGetWorkspaceIssues";
 import { WorkspaceIssueTable } from "components/Workspaces/WorkspaceIssuesTable";
 import { SubTabsList } from "components/TabList/tab-list";
+import { useMediaQuery } from "lib/hooks/useMediaQuery";
 
 const InsightUpgradeModal = dynamic(() => import("components/Workspaces/InsightUpgradeModal"));
 
@@ -106,6 +107,7 @@ const WorkspaceIssuesPage = ({ workspace, isOwner, overLimit }: WorkspaceDashboa
 
   const showBanner = isOwner && overLimit;
   const [isInsightUpgradeModalOpen, setIsInsightUpgradeModalOpen] = useState(false);
+  const isMobile = useMediaQuery("(max-width: 768px)");
 
   return (
     <>
@@ -123,18 +125,21 @@ const WorkspaceIssuesPage = ({ workspace, isOwner, overLimit }: WorkspaceDashboa
             <WorkspacesTabList workspaceId={workspace.id} selectedTab={"activity"} />
           </div>
           <div className="mt-6 grid gap-6">
-            <div className="grid md:flex justify-between gap-2 md:gap-4">
-              <SubTabsList
-                label="Activity pages"
-                textSize="small"
-                tabList={[
-                  { name: "Pull Requests", path: "activity" },
-                  { name: "Issues", path: "issues" },
-                ]}
-                selectedTab={"issues"}
-                pageId={`/workspaces/${workspace.id}`}
-              />
-              <div className="flex justify-end items-center gap-4">
+            <div className="grid md:flex gap-2 md:gap-4 w-full items-center mb-2">
+              <div className="flex items-center justify-between w-full md:w-fit">
+                <SubTabsList
+                  label="Activity pages"
+                  textSize="small"
+                  tabList={[
+                    { name: "Pull Requests", path: "activity" },
+                    { name: "Issues", path: "issues" },
+                  ]}
+                  selectedTab={"issues"}
+                  pageId={`/workspaces/${workspace.id}`}
+                />
+                {isMobile ? <DayRangePicker /> : null}
+              </div>
+              <div className="flex items-center justify-end gap-2 flex-wrap w-full">
                 <TrackedRepositoryFilter
                   options={filterOptions}
                   handleSelect={(selected: OptionKeys[]) => {
@@ -142,7 +147,7 @@ const WorkspaceIssuesPage = ({ workspace, isOwner, overLimit }: WorkspaceDashboa
                     setQueryParams({ page: "1" });
                   }}
                 />
-                <DayRangePicker />
+                {isMobile ? null : <DayRangePicker />}
                 <LimitPicker />
               </div>
             </div>


### PR DESCRIPTION
## Description

Fixes some mobile/small screen issues for workspace pages. Note that on some of the activity pages, the StarSearch button is hidden. Since that is currently feature flagged, I'll look into that in a separate PR.

Also note, that for the repository page, I made one notable change. I moved the Add Repositories button with the Share and Edit buttons.

![CleanShot 2024-07-02 at 16 17 19](https://github.com/open-sauced/app/assets/833231/7cb8ee56-6d50-4d8e-aea5-65f9a05773c9)

Prior to this PR, it was down below with the filters. This was part of the mobile fix and it looks much better. Also, the share and edit buttons weren't justified to the right. I fixed that as well.

![CleanShot 2024-07-02 at 16 18 22](https://github.com/open-sauced/app/assets/833231/864848e4-8019-4d62-9f13-60f9c8665c75)

## Related Tickets & Documents

Fixes #3667

## Mobile & Desktop Screenshots/Recordings

**Before**

Repository Page

![CleanShot 2024-07-02 at 16 14 11](https://github.com/open-sauced/app/assets/833231/222d13f8-df07-4ebf-aae9-e73bde19cda3)

Activity page (PRs)

![CleanShot 2024-07-02 at 16 08 24](https://github.com/open-sauced/app/assets/833231/e7a6a808-b2db-497c-82dc-c15bb7c825ca)

Activity page (Issues)

![CleanShot 2024-07-02 at 16 09 26](https://github.com/open-sauced/app/assets/833231/83847a93-d70f-4b33-98ae-83bfd5046545)

**After**

Repository Page

![CleanShot 2024-07-02 at 16 13 48](https://github.com/open-sauced/app/assets/833231/fff21800-9ee2-4483-a4f5-c933a7a25450)

Activity page (PRs)

![CleanShot 2024-07-02 at 16 07 07](https://github.com/open-sauced/app/assets/833231/7dcaefc2-f7a3-48b4-bc05-337f9a4839e8)

Activity page (Issues)

![CleanShot 2024-07-02 at 16 12 40](https://github.com/open-sauced/app/assets/833231/718a8ddc-12db-4061-a795-93c69ee6ac1c)

## Steps to QA

1. Visit any workspace from the deploy preview on your phone
2. Notice the workspace repository page loads without side scrolling.
3. Visit the activity pages (PRs and issues.
4. Notice the workspace repository page loads without side scrolling

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/pHMtogPBHC7Cg/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
