### PR TITLE
fix: now app sidebar menu items have the same font weight

### DIFF
--- a/components/shared/AppSidebar/sidebar-menu-item.tsx
+++ b/components/shared/AppSidebar/sidebar-menu-item.tsx
@@ -17,7 +17,7 @@ const SidebarMenuItem = ({ title, icon, type, url: href, isActive }: MenuItemPro
         className="hover:bg-slate-100 text-sm font-medium flex gap-1 items-center rounded-md transition-colors cursor-pointer tracking-tight py-1 px-2 group"
       >
         {icon}
-        <h3 className="py-1 text-slate-800">{title}</h3>
+        <span className="py-1 text-slate-800">{title}</span>
       </Link>
     </li>
   );


### PR DESCRIPTION
## Description

Now top level app sidebar menu items have the same font weight.

## Related Tickets & Documents

Fixes #3689

## Mobile & Desktop Screenshots/Recordings

Before and then After (subtle)

![CleanShot 2024-07-04 at 19 28 51](https://github.com/open-sauced/app/assets/833231/36ecb5fb-0842-4435-b344-c9f1d428cebb)

## Steps to QA

1. Open any page with the sidebar logged in.
2. Notice the font weights are the same.
3. Wait for @brandonroberts to post this animated GIF in his approval comment.

<img src="https://media0.giphy.com/media/9mtE009hcWPOesk8C4/giphy.gif"/>

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/qPcX2mzk3NmjC/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
