### PR TITLE
feat: now userprofile pages are cached for 60 seconds

### DIFF
--- a/pages/u/[username]/index.tsx
+++ b/pages/u/[username]/index.tsx
@@ -6,7 +6,6 @@ import { Person } from "schema-dts";
 import { useRouter } from "next/router";
 import SEO from "layouts/SEO/SEO";
 
-
 import useContributorPullRequests from "lib/hooks/api/useContributorPullRequests";
 import useRepoList from "lib/hooks/useRepoList";
 import { getAvatarByUsername } from "lib/utils/github";
@@ -123,6 +122,11 @@ export const getServerSideProps = async (context: UserSSRPropsContext) => {
 
   const userData = (await req.json()) as DbUser;
   const ogImage = `${process.env.NEXT_PUBLIC_OPENGRAPH_URL}/users/${username}`;
+
+  // Cache page for 60 seconds
+  context.res.setHeader("Cache-Control", "public, max-age=0, must-revalidate");
+  context.res.setHeader("Netlify-CDN-Cache-Control", "public, max-age=0, stale-while-revalidate=60");
+  context.res.setHeader("Cache-Tag", `user-profiles,user-profile-${username}`);
 
   return {
     props: { username, user: userData, ogImage },


### PR DESCRIPTION
## Description

Adds 60 second caching ā la stale while revalidate for user profile pages. On average for beta/this deploy preview, there is almost a 1.5 second speed improvement for user profile pages.

**Beta (before)**

```
❯ oha --no-tui https://beta.app.opensauced.pizza/u/nickytonline
Summary:
  Success rate: 100.00%
  Total:        14.4306 secs
  Slowest:      11.0254 secs
  Fastest:      0.5943 secs
  Average:      3.4496 secs
  Requests/sec: 13.8594

  Total data:   879.30 KiB
  Size/request: 4.40 KiB
  Size/sec:     60.93 KiB

Response time histogram:
   0.594 [1]   |
   1.637 [124] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
   2.681 [15]  |■■■
   3.724 [6]   |■
   4.767 [4]   |■
   5.810 [0]   |
   6.853 [1]   |
   7.896 [9]   |■■
   8.939 [3]   |
   9.982 [9]   |■■
  11.025 [28]  |■■■■■■■

Response time distribution:
  10.00% in 0.9719 secs
  25.00% in 1.1526 secs
  50.00% in 1.3846 secs
  75.00% in 6.6685 secs
  90.00% in 10.2409 secs
  95.00% in 10.5709 secs
  99.00% in 10.9569 secs
  99.90% in 11.0254 secs
  99.99% in 11.0254 secs


Details (average, fastest, slowest):
  DNS+dialup:   1.9333 secs, 1.2708 secs, 2.8757 secs
  DNS-lookup:   0.0004 secs, 0.0000 secs, 0.0019 secs

Status code distribution:
  [200] 200 responses
```

**This PR's Deploy Preview (after)**

```
❯ oha --no-tui https://deploy-preview-3721--oss-insights.netlify.app/u/nickytonline
Summary:
  Success rate: 100.00%
  Total:        8.6166 secs
  Slowest:      4.9569 secs
  Fastest:      0.1969 secs
  Average:      2.0104 secs
  Requests/sec: 23.2110

  Total data:   904.88 KiB
  Size/request: 4.52 KiB
  Size/sec:     105.02 KiB

Response time histogram:
  0.197 [1]  |
  0.673 [7]  |■■■■
  1.149 [40] |■■■■■■■■■■■■■■■■■■■■■■■■
  1.625 [53] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  2.101 [47] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  2.577 [4]  |■■
  3.053 [8]  |■■■■
  3.529 [5]  |■■■
  4.005 [8]  |■■■■
  4.481 [8]  |■■■■
  4.957 [19] |■■■■■■■■■■■

Response time distribution:
  10.00% in 0.9752 secs
  25.00% in 1.1597 secs
  50.00% in 1.6237 secs
  75.00% in 2.4548 secs
  90.00% in 4.4600 secs
  95.00% in 4.6585 secs
  99.00% in 4.7358 secs
  99.90% in 4.9569 secs
  99.99% in 4.9569 secs


Details (average, fastest, slowest):
  DNS+dialup:   1.9443 secs, 1.2774 secs, 2.8797 secs
  DNS-lookup:   0.0001 secs, 0.0000 secs, 0.0014 secs

Status code distribution:
  [200] 200 responses
```

## Related Tickets & Documents

Closes #3720

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. Visit a profile page, e.g. https://deploy-preview-3721--oss-insights.netlify.app/u/nickytonline
2. Open the devtools and go to the network tab
3. Refresh the page
4. Check the headers and you should see a cache hit.

![CleanShot 2024-07-16 at 14 51 23](https://github.com/user-attachments/assets/426e80d2-6de9-4b98-bf26-47188e6b81b0)



## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/izspP6uMbMeti/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
