### PR TITLE
fix: now user menu opens in the top nav

### DIFF
--- a/components/organisms/TopNav/top-nav.tsx
+++ b/components/organisms/TopNav/top-nav.tsx
@@ -18,7 +18,7 @@ const TopNav = () => {
 
   return (
     <header
-      className="top-nav-container w-full sm:fixed top-0 left-0 z-50 py-0.5 bg-light-slate-2 border-b px-2 overflow-y-hidden"
+      className="top-nav-container w-full sm:fixed top-0 left-0 z-50 py-0.5 bg-light-slate-2 border-b px-2"
       style={{
         maxHeight: "var(--top-nav-height)",
       }}


### PR DESCRIPTION
## Description

With improvements made in #3692, I had added an unnecessary overflow hidden on the top nav. This PR removes it.

## Related Tickets & Documents

Relates to #3692

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-07-16 at 15 08 13](https://github.com/user-attachments/assets/c0a7bc48-fce5-4dc1-9727-95fd5f8878ed)

**After**

![CleanShot 2024-07-16 at 15 07 47](https://github.com/user-attachments/assets/7821f492-1e7c-403d-9fd6-3bd242d327d5)

## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/3ohzdYJK1wAdPWVk88/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
