### PR TITLE
feat: added posthog analytics for StarSearch for Workspaces

### DIFF
--- a/components/StarSearch/StarSearchChat.tsx
+++ b/components/StarSearch/StarSearchChat.tsx
@@ -76,6 +76,7 @@ type StarSearchChatProps = {
   onClose?: () => void;
   baseApiStarSearchUrl?: URL;
   sharingEnabled?: boolean;
+  isWorkspace?: boolean;
 };
 
 export function StarSearchChat({
@@ -91,6 +92,7 @@ export function StarSearchChat({
   baseApiStarSearchUrl = DEFAULT_STAR_SEARCH_API_BASE_URL,
   sharingEnabled = true,
   showTopNavigation = false,
+  isWorkspace = false,
 }: StarSearchChatProps) {
   const [starSearchState, setStarSearchState] = useState<"initial" | "chat">("initial");
   const [chat, setChat] = useState<StarSearchChatMessage[]>([]);
@@ -98,7 +100,7 @@ export function StarSearchChat({
   const [isRunning, setIsRunning] = useState(false);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [ranOnce, setRanOnce] = useState(false);
-  const { feedback, prompt } = useStarSearchFeedback();
+  const { feedback, prompt } = useStarSearchFeedback(isWorkspace);
   const { toast } = useToast();
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const [checkAuth, setCheckAuth] = useState(false);

--- a/lib/hooks/useStarSearchFeedback.ts
+++ b/lib/hooks/useStarSearchFeedback.ts
@@ -11,18 +11,18 @@ export interface StarSearchPromptAnalytic {
   promptResponse: string;
 }
 
-export const useStarSearchFeedback = () => {
+export const useStarSearchFeedback = (isWorkspace: boolean) => {
   const posthog = usePostHog();
 
   const prompt = ({ promptContent, promptResponse }: StarSearchPromptAnalytic) => {
-    posthog.capture("star_search_prompt", {
+    posthog.capture(isWorkspace ? "star_search_workspace_prompt" : "star_search_prompt", {
       promptContent,
       promptResponse,
     } satisfies StarSearchPromptAnalytic);
   };
 
   const feedback = ({ feedback, promptContent, promptResponse }: StarSearchFeedbackAnalytic) => {
-    posthog.capture("star_search_feedback", {
+    posthog.capture(isWorkspace ? "star_search_workspace_feedback" : "star_search_feedback", {
       feedback,
       promptContent,
       promptResponse,


### PR DESCRIPTION
## Description

Adds analytics to see when a user clicks on the StarSearch for workspaces CTA (logged in, logged out, no access) as well as the prompts and response via feedback like standalone StarSearch.

## Related Tickets & Documents

Closes #3747

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

Logged out

1. Open your dev tools
1. Go to a workspace
1. Click the StarSearch for workspaces CTA in the bottom right.
1. Notice the posthog analytic generated for the `star_search_workspace_cta_click` event with a property called `type` with the value `sign_in`.

Logged in

1. Open your dev tools
1. Go to a workspace
1. Click the StarSearch for workspaces CTA in the bottom right.
1. Notice the posthog analytic generated for the `star_search_workspace_cta_click` event
1. If you're an editor of the workspace, the even's property called `type` with the value `can_access`. If you're not an editor, it will have a value of `no_access`. 

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/xT9C25UNTwfZuk85WP/giphy-downsized-medium.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
