### PR TITLE
fix: now StarSearch for Workspaces resets when changing workspaces

### DIFF
--- a/components/StarSearch/StarSearchChat.tsx
+++ b/components/StarSearch/StarSearchChat.tsx
@@ -76,7 +76,7 @@ type StarSearchChatProps = {
   onClose?: () => void;
   baseApiStarSearchUrl?: URL;
   sharingEnabled?: boolean;
-  isWorkspace?: boolean;
+  workspaceId?: string;
 };
 
 export function StarSearchChat({
@@ -92,7 +92,7 @@ export function StarSearchChat({
   baseApiStarSearchUrl = DEFAULT_STAR_SEARCH_API_BASE_URL,
   sharingEnabled = true,
   showTopNavigation = false,
-  isWorkspace = false,
+  workspaceId,
 }: StarSearchChatProps) {
   const [starSearchState, setStarSearchState] = useState<"initial" | "chat">("initial");
   const [chat, setChat] = useState<StarSearchChatMessage[]>([]);
@@ -100,7 +100,7 @@ export function StarSearchChat({
   const [isRunning, setIsRunning] = useState(false);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [ranOnce, setRanOnce] = useState(false);
-  const { feedback, prompt } = useStarSearchFeedback(isWorkspace);
+  const { feedback, prompt } = useStarSearchFeedback(!!workspaceId);
   const { toast } = useToast();
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const [checkAuth, setCheckAuth] = useState(false);
@@ -108,6 +108,14 @@ export function StarSearchChat({
   const [view, setView] = useState<"prompt" | "chat">("prompt");
   const [shareLinkError, setShareLinkError] = useState(false);
   const streamRef = useRef<ReadableStreamDefaultReader<string>>();
+
+  useEffect(() => {
+    if (!workspaceId) {
+      return;
+    }
+
+    onNewChat();
+  }, [workspaceId]);
 
   const onNewChat = () => {
     streamRef.current?.cancel();

--- a/components/StarSearch/StarSearchEmbed.tsx
+++ b/components/StarSearch/StarSearchEmbed.tsx
@@ -111,7 +111,7 @@ export const StarSearchEmbed = ({
         }}
       >
         <StarSearchChat
-          isWorkspace={!!validWorkspaceId}
+          workspaceId={validWorkspaceId}
           userId={userId}
           sharedChatId={sharedChatId}
           bearerToken={bearerToken}


### PR DESCRIPTION
## Description

Now StarSearch for Workspaces resets when changing workspaces. You could still use StarSearch in the new workspace, but it was confusing to see the previous workspace's StarSearch conversation.

## Related Tickets & Documents

Fixes #3755

## Mobile & Desktop Screenshots/Recordings

**Before**

https://github.com/user-attachments/assets/2b97e377-dc0e-4c9a-9326-6daa966d1e42

**After**

https://github.com/user-attachments/assets/ee5850f3-e016-4741-95cb-abf2379b2230

## Steps to QA

1. Go to any workspace where you have access to StarSearch
2. Ask a question
3. Switch to another workspace (it can be in the middle of running the current prompt/response stream)
4. Notice that StarSearch for workspaces resets to the initial screen.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/vIpCeF7YcCrygqAn3R/giphy-downsized-medium.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
