### PR TITLE
fix: now StarSearch history resets if workspace changes

### DIFF
--- a/lib/hooks/api/useGetStarSearchWorkspaceHistory.ts
+++ b/lib/hooks/api/useGetStarSearchWorkspaceHistory.ts
@@ -43,6 +43,10 @@ export const useGetStarSearchWorkspaceHistory = ({
     publicApiFetcher as Fetcher<PaginatedResponse, Error>
   );
 
+  useEffect(() => {
+    setHistory([]);
+  }, [workspaceId]);
+
   /**
    * When the page changes, we need to add the new mutate function to the list of mutations
    * so that we can call all of them and ensure that the history is up to date since we're


### PR DESCRIPTION
## Description

Now when you switch workspaces, StarSearch history reloads with the current workspace StarSearch history instead of concatenating or staying on the previous workspace's StarSEarch history.

## Related Tickets & Documents

Closes #3776

## Mobile & Desktop Screenshots/Recordings

![CleanShot 2024-07-25 at 17 19 48](https://github.com/user-attachments/assets/1c8962d3-d3ea-4bae-a86e-c2cc1d2f5d1f)

## Steps to QA

1. Go to a workspace and open it's StarSearch history.
2. Note some of the StarSearch history items.
3. Switch to another workspace.
4. Open the StarSearch history.
5. Notice the history is different.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/jnmsc0Z910FW6nawKM/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
