### PR TITLE
fix: now pinned table columns only get pinned when embedded StarSearch is closed

### DIFF
--- a/components/StarSearch/StarSearchEmbed.tsx
+++ b/components/StarSearch/StarSearchEmbed.tsx
@@ -106,7 +106,6 @@ export const StarSearchEmbed = ({
         style={{
           top: "var(--top-nav-height)",
           height: "calc(100dvh - var(--top-nav-height))",
-          zIndex: 1,
         }}
       >
         <StarSearchChat

--- a/components/Workspaces/WorkspaceIssuesTable.tsx
+++ b/components/Workspaces/WorkspaceIssuesTable.tsx
@@ -159,7 +159,6 @@ const getCommonPinningStyles = (column: Column<DbRepoIssueEvents>): CSSPropertie
     right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
     position: isPinned ? "sticky" : "relative",
     width: column.getSize(),
-    zIndex: isPinned ? 1 : 0,
   };
 };
 
@@ -203,7 +202,11 @@ export const WorkspaceIssueTable = ({ data, meta, isLoading }: WorkspaceIssueTab
                   <TableHead
                     key={header.id}
                     style={{ ...getCommonPinningStyles(header.column), width: header.column.getSize() }}
-                    className={clsx(header.column.getIsPinned(), "bg-light-slate-3")}
+                    className={clsx(
+                      header.column.getIsPinned(),
+                      "bg-light-slate-3",
+                      header.column.getIsPinned() && "pinned-table-column"
+                    )}
                   >
                     <div className="flex items-center">
                       {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
@@ -261,7 +264,11 @@ export const WorkspaceIssueTable = ({ data, meta, isLoading }: WorkspaceIssueTab
                     <TableCell
                       key={cell.id}
                       style={{ ...getCommonPinningStyles(cell.column), width: cell.column.getSize() }}
-                      className={clsx(cell.column.getIsPinned(), "bg-white")}
+                      className={clsx(
+                        cell.column.getIsPinned(),
+                        "bg-white",
+                        cell.column.getIsPinned() && "pinned-table-column"
+                      )}
                     >
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </TableCell>

--- a/components/Workspaces/WorkspacePullRequestsTable.tsx
+++ b/components/Workspaces/WorkspacePullRequestsTable.tsx
@@ -191,7 +191,6 @@ const getCommonPinningStyles = (column: Column<DbRepoPREvents>): CSSProperties =
     right: isPinned === "right" ? `${column.getAfter("right")}px` : undefined,
     position: isPinned ? "sticky" : "relative",
     width: column.getSize(),
-    zIndex: isPinned ? 1 : 0,
   };
 };
 
@@ -235,7 +234,11 @@ export const WorkspacePullRequestTable = ({ data, meta, isLoading }: WorkspacePu
                   <TableHead
                     key={header.id}
                     style={{ ...getCommonPinningStyles(header.column), width: header.column.getSize() }}
-                    className={clsx(header.column.getIsPinned(), "bg-light-slate-3")}
+                    className={clsx(
+                      header.column.getIsPinned(),
+                      "bg-light-slate-3",
+                      header.column.getIsPinned() && "pinned-table-column"
+                    )}
                   >
                     {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                     {enableSorting ? (
@@ -291,7 +294,11 @@ export const WorkspacePullRequestTable = ({ data, meta, isLoading }: WorkspacePu
                     <TableCell
                       key={cell.id}
                       style={{ ...getCommonPinningStyles(cell.column), width: cell.column.getSize() }}
-                      className={clsx(cell.column.getIsPinned(), "bg-white")}
+                      className={clsx(
+                        cell.column.getIsPinned(),
+                        "bg-white",
+                        cell.column.getIsPinned() && "pinned-table-column"
+                      )}
                     >
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </TableCell>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -282,3 +282,12 @@ body:has([aria-hidden="false"][data-star-search-mobile]) {
 body:has([data-star-search-mobile]) .top-nav-container {
   @apply fixed;
 }
+
+/**
+  * The pinned-table-column CSS class is for our tables that have pinned columns.
+  * When embedded StarSearch is open, we want to ensure that the columns unpin so they
+  * don't leak throug the embedded StarSearch panel.
+  */
+body:not(:has([data-star-search-mobile][aria-hidden="false"])) .pinned-table-column {
+  z-index: 1;
+}


### PR DESCRIPTION
## Description

Now hover cards appear over the StarSearch for Workspaces panel and are no longer hidden.

## Related Tickets & Documents

Fixes #3773

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-07-25 at 19 54 35](https://github.com/user-attachments/assets/e87474b8-88ed-44fe-bc81-038cc211c4eb)

**After**

![CleanShot 2024-07-25 at 19 54 11](https://github.com/user-attachments/assets/8fc2c502-077c-4b0a-a87d-0dc1d1e3b871)

## Steps to QA

1. Test this on the two activity pages of workspaces: pull request and issue pages.
2. Ask StarSearch for workspaces a question about contributors.
3. It should return a response with user links that have the hover avatar beside them.
4. Hover over the avatar.
5. Notice the hover card is on top of everything else.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/CdAh3Sh0Mvtdu/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
