### PR TITLE
fix: Upgrades email validation regex to the more agnostic HTML5 regex

### DIFF
--- a/components/molecules/NewsletterForm/newsletter-form.tsx
+++ b/components/molecules/NewsletterForm/newsletter-form.tsx
@@ -47,8 +47,7 @@ const NewsletterForm = () => {
 
   const handleChange = (value: string) => {
     setEmail(value);
-    const isValidEmail = validateEmail(email);
-    setIsValidEmail(!!isValidEmail);
+    setIsValidEmail(validateEmail(email));
   };
 
   useEffect(() => {

--- a/components/molecules/TeamMembersConfig/team-members-config.tsx
+++ b/components/molecules/TeamMembersConfig/team-members-config.tsx
@@ -38,8 +38,7 @@ const TeamMembersConfig = ({
 
   const handleChange = async (value: string) => {
     setEmail(value);
-
-    setValidInput(!!validateEmail(value));
+    setValidInput(validateEmail(value));
   };
 
   const handleAddMember = async () => {

--- a/components/organisms/UserSettingsPage/user-settings-page.tsx
+++ b/components/organisms/UserSettingsPage/user-settings-page.tsx
@@ -151,12 +151,7 @@ const UserSettingsPage = ({ user }: UserSettingsPageProps) => {
 
   const handleEmailChange = (value: string) => {
     setEmail(value);
-
-    if (validateEmail(value)) {
-      setIsValidEmail(true);
-    } else {
-      setIsValidEmail(false);
-    }
+    setIsValidEmail(validateEmail(value));
   };
 
   const handleTwitterUsernameChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/lib/utils/validate-email.test.ts
+++ b/lib/utils/validate-email.test.ts
@@ -1,7 +1,28 @@
 import { validateEmail } from "lib/utils/validate-email";
 
 describe("[lib] validateEmail()", () => {
-  it("Should return true if string is a valid email", () => {
+  it(".co domain return true if string is a valid email", () => {
+    const testString = "nick@nickyt.co";
+    const result = validateEmail(testString);
+
+    expect(result).toBeTruthy();
+  });
+
+  it(".me domain return true if string is a valid email", () => {
+    const testString = "self@bjoern-buettner.me";
+    const result = validateEmail(testString);
+
+    expect(result).toBeTruthy();
+  });
+
+  it(".site domain return true if string is a valid email", () => {
+    const testString = "self@bjoern-buettner.site";
+    const result = validateEmail(testString);
+
+    expect(result).toBeTruthy();
+  });
+
+  it(".yahoo domain return true if string is a valid email", () => {
     const testString = "ahmedatwa@yahoo.com";
     const result = validateEmail(testString);
 
@@ -12,11 +33,6 @@ describe("[lib] validateEmail()", () => {
     let testString = "ahmedatwayahoo.com";
     let result = validateEmail(testString);
 
-    expect(result).toBeFalsy();
-
-    testString = "ahmedatwa@yahoo";
-
-    result = validateEmail(testString);
     expect(result).toBeFalsy();
   });
 });

--- a/lib/utils/validate-email.ts
+++ b/lib/utils/validate-email.ts
@@ -1,7 +1,17 @@
-export const validateEmail = (email: string) => {
-  return String(email)
-    .toLowerCase()
-    .match(
-      /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
-    );
-};
+/*
+ * the following is a simple regular expression based on the HTML 5 specification
+ * which defines what a valid email address is. This can be used to test if a user
+ * provided email passes the spec but is not all encompassing:
+ *
+ * As many others throughout the years have said, the only REAL way to test if an email
+ * is actually valid is to send an email to that address.
+ *
+ * Attribution: HTML 5 "valid email address" spec - https://html.spec.whatwg.org/#valid-e-mail-address
+ * Attribution: Webkit browser validation - https://trac.webkit.org/browser/webkit/trunk/Source/WebCore/html/EmailInputType.cpp
+ */
+
+export const validEmailRegex = new RegExp(
+  /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+);
+
+export const validateEmail = (email: string) => validEmailRegex.test(email);


### PR DESCRIPTION
## Description

This upgrades the valid email regex to the more agnostic HTML5 regex used in webpack. This is a relatively simple email validation regex and _mostly_ looks for a valid `@` preceded by valid email text and followed by a valid address / domain.

_Technically_ only the email provider can actually validate an email. But this at least fixes issues we're having with domains that are valid (like `.me` or `.co`)

Thanks to @Idrinth for the original PR (attribution included in co-author)

## Related Tickets & Documents

Closes: https://github.com/open-sauced/app/issues/3795
Closes: https://github.com/open-sauced/app/issues/3271
Closes: https://github.com/open-sauced/app/pull/3273

## Mobile & Desktop Screenshots/Recordings

Works with `nick@nickyt.co`:

![Screenshot 2024-07-29 at 1 04 18 PM](https://github.com/user-attachments/assets/1d888b3d-aeff-4535-a239-81893bee9b61)

## Steps to QA

1. Run app
2. Use email form in Highlights
3. Use email form in personal profile

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4