### PR TITLE
fix: added a no rating view for OSCR component

### DIFF
--- a/components/Contributors/OscrPill.stories.tsx
+++ b/components/Contributors/OscrPill.stories.tsx
@@ -19,6 +19,13 @@ export const Default: Story = {
     hideRating: false,
   },
 };
+
+export const NoRating: Story = {
+  args: {
+    rating: 0,
+  },
+};
+
 export const Blurred: Story = {
   args: {
     hideRating: true,

--- a/components/Contributors/OscrPill.tsx
+++ b/components/Contributors/OscrPill.tsx
@@ -2,10 +2,10 @@ import Pill from "components/atoms/Pill/pill";
 import Tooltip from "components/atoms/Tooltip/tooltip";
 
 export const OscrPill = ({ rating, hideRating }: { rating: number | undefined; hideRating: boolean }) => {
-  let percentageRating = rating ? Math.floor(rating * 100) : 0;
+  let ratingToDisplay = rating ? Math.floor(rating * 100) : 0;
 
-  if (percentageRating < 1) {
-    percentageRating = 0;
+  if (ratingToDisplay < 1) {
+    ratingToDisplay = 0;
   }
 
   return (
@@ -13,7 +13,7 @@ export const OscrPill = ({ rating, hideRating }: { rating: number | undefined; h
       {hideRating ? (
         <Pill color="purple" size="small" text="00" blurText={true} />
       ) : (
-        <Pill color="purple" size="small" text={`${percentageRating}`} />
+        <>{ratingToDisplay > 0 ? <Pill color="purple" size="small" text={`${ratingToDisplay}`} /> : <span>-</span>}</>
       )}
     </Tooltip>
   );


### PR DESCRIPTION
## Description

Now the OSCR component has a no rating view.

## Related Tickets & Documents

Relates to #3804

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-07-30 at 17 27 32](https://github.com/user-attachments/assets/a97fc6ea-5507-49da-a963-9e8b98d7e1af)

![CleanShot 2024-07-30 at 17 24 05](https://github.com/user-attachments/assets/9da205b2-e105-400d-b1fb-d4df95905523)

**After**

![CleanShot 2024-07-30 at 17 27 53](https://github.com/user-attachments/assets/51671539-4f3c-400d-a792-8ddc1142f3ae)

![CleanShot 2024-07-30 at 17 23 03](https://github.com/user-attachments/assets/d20364a3-d4a8-4744-b145-3e62d16c23b2)



## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/l0IybQ6l8nfKjxQv6/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
