### PR TITLE
feat: now OSCR component has a CTA to log in if logged out

### DIFF
--- a/components/Contributors/OscrPill.stories.tsx
+++ b/components/Contributors/OscrPill.stories.tsx
@@ -1,3 +1,4 @@
+import { OAuthResponse } from "@supabase/supabase-js";
 import { OscrPill } from "components/Contributors/OscrPill";
 import type { Meta, StoryObj } from "@storybook/react";
 
@@ -7,6 +8,7 @@ const meta: MetaData = {
   title: "Components/Contributors/OscrRating",
   component: OscrPill,
   args: {
+    signIn: (options) => Promise.resolve({} as OAuthResponse),
     rating: 0.5,
   },
 };

--- a/components/Contributors/OscrPill.tsx
+++ b/components/Contributors/OscrPill.tsx
@@ -28,7 +28,9 @@ export const OscrPill = ({
       {hideRating ? (
         <button onClick={() => signIn({ provider: "github", options: { redirectTo: window.location.href } })}>
           <span className="sr-only">Login to view Open Source Contributor Rating (OSCR)</span>
-          <Pill color="purple" size="small" text="00" blurText={true} />
+          <span aria-hidden={true}>
+            <Pill color="purple" size="small" text="00" blurText={true} />
+          </span>
         </button>
       ) : (
         <Pill color="purple" size="small" text={`${percentageRating}`} />

--- a/components/Contributors/OscrPill.tsx
+++ b/components/Contributors/OscrPill.tsx
@@ -1,17 +1,35 @@
 import Pill from "components/atoms/Pill/pill";
 import Tooltip from "components/atoms/Tooltip/tooltip";
+import { supabase } from "lib/utils/supabase";
 
-export const OscrPill = ({ rating, hideRating }: { rating: number | undefined; hideRating: boolean }) => {
+const DEFAULT_SIGN_IN = supabase.auth.signInWithOAuth.bind(supabase.auth);
+
+export const OscrPill = ({
+  rating,
+  hideRating,
+  signIn = DEFAULT_SIGN_IN,
+}: {
+  rating: number | undefined;
+  hideRating: boolean;
+  signIn?: typeof DEFAULT_SIGN_IN;
+}) => {
   let percentageRating = rating ? Math.floor(rating * 100) : 0;
 
   if (percentageRating < 1) {
     percentageRating = 0;
   }
 
+  const tooltipText = hideRating
+    ? "Login to view Open Source Contributor Rating (OSCR)"
+    : "Open Source Contributor Rating (OSCR)";
+
   return (
-    <Tooltip direction="top" content="Open Source Contributor Rating (OSCR)">
+    <Tooltip direction="top" content={tooltipText}>
       {hideRating ? (
-        <Pill color="purple" size="small" text="00" blurText={true} />
+        <button onClick={() => signIn({ provider: "github", options: { redirectTo: window.location.href } })}>
+          <span className="sr-only">Login to view Open Source Contributor Rating (OSCR)</span>
+          <Pill color="purple" size="small" text="00" blurText={true} />
+        </button>
       ) : (
         <Pill color="purple" size="small" text={`${percentageRating}`} />
       )}

--- a/e2e/workspace-contributor-insight.spec.ts
+++ b/e2e/workspace-contributor-insight.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@playwright/test";
+
+const WORKSPACE_ID = "21c5e583-f1fd-4033-9ec9-7801f67ff727";
+
+test("workspace contributor insight page loads", async ({ page }) => {
+  await page.goto(`/workspaces/${WORKSPACE_ID}/contributor-insights/40691f9c-e575-4349-a0aa-73beb581f99f/overview`);
+
+  // There is more than one row of users, but we only want the first one to test the login CTA
+  // for viewing OSCRs.
+  await page
+    .getByRole("button", { name: "Login to view Open Source Contributor Rating (OSCR)", exact: true })
+    .first()
+    .click();
+
+  await expect(page.url()).toContain("https://github.com/login");
+});


### PR DESCRIPTION
## Description

Now the OSCR component has a CTA to log in if logged out/are a guest,

## Related Tickets & Documents

Closes #3810
Relates to #3802

## Mobile & Desktop Screenshots/Recordings

![CleanShot 2024-07-30 at 23 20 44](https://github.com/user-attachments/assets/cf67b91f-d5ca-4832-a2c8-692e82f2e4f3)

## Steps to QA

1. Ensure you're logged out
2. Go to a page that has the OSCR in a grid, e.g. https://deploy-preview-3814--oss-insights.netlify.app/workspaces/3432aaf7-55db-4c2b-9fde-f61604471e21/contributor-insights/aaf5ec66-9d3a-456d-b62b-05410e0b2fa4/overview
3. Tab to a blurred OSCR or hover over it.
4. The tooltip says to login to view the OSCR
5. Click on the blurred score.
6. You're logged in and now the scores are visible.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [X] Tier 3
- [ ] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/hi2kPofVMW70k/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
