### PR TITLE
chore: set the number of workers to 3 for Playwright GitHub action

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 3 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
## Description

Increases the number of workers in the Playwright GitHub action to three which should shorten the amount of time for E2E tests to run.

## Related Tickets & Documents

Closes #3815

## Mobile & Desktop Screenshots/Recordings

![CleanShot 2024-07-31 at 00 28 56](https://github.com/user-attachments/assets/f878f1e4-4ba0-48d9-9afb-257eed273094)

## Steps to QA

N/A

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/mdfPpglf2c0QxED151/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
