### PR TITLE
fix: updated OSCR login CTA for OSCR pill component

### DIFF
--- a/components/Contributors/Oscr.tsx
+++ b/components/Contributors/Oscr.tsx
@@ -28,17 +28,20 @@ export const OscrPill = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN }: OscrP
   return (
     <Tooltip direction="top" content={tooltipText}>
       {hideRating ? (
-        <button
-          onClick={() => {
-            posthog.capture("OSCR Login Button Clicked");
-            signIn({ provider: "github", options: { redirectTo: window.location.href } });
-          }}
-        >
-          <span className="sr-only">Login to view Open Source Contributor Rating (OSCR)</span>
-          <span aria-hidden={true}>
-            <Pill color="purple" size="small" text="00" blurText={true} />
-          </span>
-        </button>
+        <div className="relative flex items-center justify-center w-fit">
+          <span className="absolute blur-sm text-xl text-purple-800 z-0 leading-tight">000</span>
+          <Button
+            variant="primary"
+            className="flex items-center gap-2 !p-1 !text-xs z-10"
+            onClick={() => {
+              posthog.capture("OSCR Login Button Clicked");
+              signIn({ provider: "github", options: { redirectTo: window.location.href } });
+            }}
+          >
+            <span className="sr-only">Login in to view Open Source Contributor Rating (OSCR)</span>
+            <LockIcon size={16} />
+          </Button>
+        </div>
       ) : (
         <Pill color="purple" size="small" text={`${ratingToRender}`} />
       )}
@@ -53,7 +56,7 @@ export const OscrButton = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN }: Osc
   return (
     <>
       {hideRating ? (
-        <Tooltip direction="top" content="Login in to view Open Source Contributor Rating (OSCR)" className="z-1">
+        <Tooltip direction="top" content="Login in to view Open Source Contributor Rating (OSCR)">
           <div className="relative flex items-center justify-center w-fit">
             <span className="absolute blur-sm text-xl text-black z-0 leading-tight">000</span>
             <Button

--- a/components/Contributors/Oscr.tsx
+++ b/components/Contributors/Oscr.tsx
@@ -13,6 +13,8 @@ interface OscrProps {
   signIn?: typeof DEFAULT_SIGN_IN;
 }
 
+export const OSCR_LOGIN_TEXT = "Log in to view Open Source Contributor Rating (OSCR)";
+
 export const OscrPill = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN }: OscrProps) => {
   const posthog = usePostHog();
   let ratingToRender = rating ? Math.floor(rating * 100) : 0;
@@ -21,15 +23,13 @@ export const OscrPill = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN }: OscrP
     ratingToRender = 0;
   }
 
-  const tooltipText = hideRating
-    ? "Login to view Open Source Contributor Rating (OSCR)"
-    : "Open Source Contributor Rating (OSCR)";
+  const tooltipText = hideRating ? OSCR_LOGIN_TEXT : "Open Source Contributor Rating (OSCR)";
 
   return (
     <Tooltip direction="top" content={tooltipText}>
       {hideRating ? (
         <div className="relative flex items-center justify-center w-fit">
-          <span className="absolute blur-sm text-xl text-purple-800 z-0 leading-tight">000</span>
+          <span className="absolute blur-sm text-xl text-purple-00 z-0 leading-tight">000</span>
           <Button
             variant="primary"
             className="flex items-center gap-2 !p-1 !text-xs z-10"
@@ -38,7 +38,7 @@ export const OscrPill = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN }: OscrP
               signIn({ provider: "github", options: { redirectTo: window.location.href } });
             }}
           >
-            <span className="sr-only">Login in to view Open Source Contributor Rating (OSCR)</span>
+            <span className="sr-only">{OSCR_LOGIN_TEXT}</span>
             <LockIcon size={16} />
           </Button>
         </div>
@@ -53,10 +53,14 @@ export const OscrButton = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN }: Osc
   const posthog = usePostHog();
   let ratingToRender = rating ? Math.floor(rating * 100) : 0;
 
+  const tooltipText = hideRating
+    ? "Log in to view Open Source Contributor Rating (OSCR)"
+    : "Open Source Contributor Rating (OSCR)";
+
   return (
     <>
       {hideRating ? (
-        <Tooltip direction="top" content="Login in to view Open Source Contributor Rating (OSCR)">
+        <Tooltip direction="top" content={OSCR_LOGIN_TEXT}>
           <div className="relative flex items-center justify-center w-fit">
             <span className="absolute blur-sm text-xl text-black z-0 leading-tight">000</span>
             <Button
@@ -67,7 +71,7 @@ export const OscrButton = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN }: Osc
                 signIn({ provider: "github", options: { redirectTo: window.location.href } });
               }}
             >
-              <span className="sr-only">Login in to view Open Source Contributor Rating (OSCR)</span>
+              <span className="sr-only">{OSCR_LOGIN_TEXT}</span>
               <LockIcon size={16} />
             </Button>
           </div>

--- a/e2e/user-profile.spec.ts
+++ b/e2e/user-profile.spec.ts
@@ -12,7 +12,7 @@ test("Loads user profile page", async ({ page }) => {
 
   // Check for login button for viewing OSCR
   await page
-    .getByRole("button", { name: "Login in to view  Open Source Contributor Rating (OSCR)", exact: true })
+    .getByRole("button", { name: "Log in to view  Open Source Contributor Rating (OSCR)", exact: true })
     .click();
 
   await expect(page.url()).toContain("https://github.com/login");

--- a/e2e/workspace-contributor-insight.spec.ts
+++ b/e2e/workspace-contributor-insight.spec.ts
@@ -8,7 +8,7 @@ test("workspace contributor insight page loads", async ({ page }) => {
   // There is more than one row of users, but we only want the first one to test the login CTA
   // for viewing OSCRs.
   await page
-    .getByRole("button", { name: "Login to view Open Source Contributor Rating (OSCR)", exact: true })
+    .getByRole("button", { name: "Log in to view Open Source Contributor Rating (OSCR)", exact: true })
     .first()
     .click();
 


### PR DESCRIPTION
## Description

Adds the same lock button to the OSCR pill component that the OSCR component on the user profile has.

## Related Tickets & Documents

Relates to #3814

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-08-01 at 12 19 57](https://github.com/user-attachments/assets/c8b3405b-9f66-44ea-a8f5-924c0baea5cc)

**After**

![CleanShot 2024-08-01 at 12 19 28](https://github.com/user-attachments/assets/653af56f-609a-4795-ae78-883b7b082af6)

## Steps to QA

1. Ensure you're logged out.
2. Go to https://deploy-preview-3823--oss-insights.netlify.app/workspaces/3432aaf7-55db-4c2b-9fde-f61604471e21/contributor-insights/aaf5ec66-9d3a-456d-b62b-05410e0b2fa4/overview
3. Notice the lock button over the OSCR ratings.
4. Click on one of the lock buttons.
5. You're logged in an see OSCR ratings now.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/5QXWRp1CNGnMnZunC3/giphy-downsized-medium.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
