### PR TITLE
feat: OSCR works with API range 0-300 and uses ceiling math

### DIFF
--- a/components/Contributors/Oscr.tsx
+++ b/components/Contributors/Oscr.tsx
@@ -17,7 +17,7 @@ export const OSCR_LOGIN_TEXT = "Log in to view Open Source Contributor Rating (O
 
 export const OscrPill = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN }: OscrProps) => {
   const posthog = usePostHog();
-  let ratingToRender = rating ? Math.floor(rating * 100) : 0;
+  let ratingToRender = rating ? Math.ceil(rating) : 0;
 
   if (ratingToRender < 1) {
     ratingToRender = 0;
@@ -51,7 +51,7 @@ export const OscrPill = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN }: OscrP
 
 export const OscrButton = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN }: OscrProps) => {
   const posthog = usePostHog();
-  let ratingToRender = rating ? Math.floor(rating * 100) : 0;
+  let ratingToRender = rating ? Math.ceil(rating) : 0;
 
   const tooltipText = hideRating
     ? "Log in to view Open Source Contributor Rating (OSCR)"


### PR DESCRIPTION
## Description

Makes the OSCR math us `math.ceil` for ceiling math. This depends on: https://github.com/open-sauced/api/pull/990 which sets the OSCRs in the API from 0-300 (instead of straight percentages like 0.83)

## Related Tickets & Documents

Depends on: https://github.com/open-sauced/api/pull/990

## Steps to QA

1. Run app with API running locally or pointed to beta
2. Go to a user's profile, see OSCR is between 0-300

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4