### PR TITLE
fix: now using setQueryParams no longer causes page to jump

### DIFF
--- a/lib/utils/query-params.ts
+++ b/lib/utils/query-params.ts
@@ -6,18 +6,28 @@ import Router from "next/router";
  * @param {Record<string, string>} params - An object containing key-value pairs of query parameters to set. Pass in `{}`(an empty object) to skip.
  * @param {Array<string>} [paramsToRemove=[]] - An optional array of query parameter keys to remove from the URL. To skip use `[]`(an empty array).
  * @param {string | undefined} [pathname] - An optional variable for providing the pathname to go to.
+ * @param {boolean} [scroll=false] - An optional boolean to enable or disable scrolling to the top of the page.
  */
-function setQueryParams(params: Record<string, string>, paramsToRemove: Array<string> = [], pathname?: string) {
+function setQueryParams(
+  params: Record<string, string>,
+  paramsToRemove: Array<string> = [],
+  pathname?: string,
+  scroll = false
+) {
   const presentQueryParams = deleteKeys(Router.query, paramsToRemove);
 
   // Merge final query and set URL
-  Router.push({
-    pathname: pathname || Router.pathname,
-    query: {
-      ...presentQueryParams,
-      ...params,
+  Router.push(
+    {
+      pathname: pathname || Router.pathname,
+      query: {
+        ...presentQueryParams,
+        ...params,
+      },
     },
-  });
+    undefined,
+    { scroll }
+  );
 }
 
 function deleteKeys<T extends ParsedUrlQuery, K extends keyof T>(obj: T, keys: K[]): T {


### PR DESCRIPTION
## Description

Now by default, if you use `setQueryParams` to added querystring parameters to the URL, the page no longer jumps. If for some reason you need it to scroll to the top, pass in `true` for `scroll`.

## Related Tickets & Documents

Closes #3836

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-08-02 at 11 33 30](https://github.com/user-attachments/assets/457efa46-e045-4805-889a-bbf1bab4e493)

**After**

![CleanShot 2024-08-02 at 11 33 03](https://github.com/user-attachments/assets/5e174c2e-2590-41f7-bdf3-9f7f446903ea)

## Steps to QA

1. Go to a user profile, e.g. `/u/nickytonline`
2. Resize the window so it scrolls down a bit.
3. Click on one of the tabs, e.g. Recommendations.
4. The page refreshes and no longer scrolls to the top.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/4xWGyVKoXqg2eVCiq9/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
