### PR TITLE
chore: Small cleanup of hanging "Hacktoberfest" references

### DIFF
--- a/components/atoms/FilterCard/filterCard.stories.tsx
+++ b/components/atoms/FilterCard/filterCard.stories.tsx
@@ -23,8 +23,8 @@ const FilterCardTemplate: ComponentStory<typeof FilterCard> = (args) => <FilterC
 
 // FilterCard Default
 export const Default = FilterCardTemplate.bind({});
-Default.args = { filterName: "hacktoberfest", isRemovable: false };
+Default.args = { filterName: "Most Active", isRemovable: false };
 
 // FilterCard Removable
 export const Removable = FilterCardTemplate.bind({});
-Removable.args = { filterName: "hacktoberfest", isRemovable: true };
+Removable.args = { filterName: "Most Active", isRemovable: true };


### PR DESCRIPTION
## Description

Small cleanup of hanging hacktoberfest references. This was just a story so replaced with a different filter label in the explore feed.

## Related Tickets & Documents

Closes: https://github.com/open-sauced/app/issues/2514#issuecomment-2270017555

## Steps to QA

No other hacktoberfest references found (besides the automated changelog):

```
❯ rg -i -l hacktoberfest
CHANGELOG.md
```

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExM2c1cGt5aGFsb3NjZnR1NjRtM2d0aTJ4aG9qZzIzdmZsYXFkaDllbiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/dJEMs13SrsiuA/giphy.gif)