### PR TITLE
fix: now layout toggles are radio buttons

### DIFF
--- a/components/atoms/LayoutToggle/layout-toggle.tsx
+++ b/components/atoms/LayoutToggle/layout-toggle.tsx
@@ -16,26 +16,32 @@ const LayoutToggle = ({ value, onChange }: LayoutToggleProps) => {
 
   return (
     <div className="flex h-8 border rounded-lg shadow-xs w-28 p-[1px] text-light-slate-9">
-      <div
+      <button
+        role="radio"
+        aria-checked={value === "list"}
+        name="layout"
         onClick={() => handleToggle("list")}
-        role="toggle"
         className={clsx(
-          "flex items-center cursor-pointer justify-center flex-1 transition rounded-lg",
-          value === "list" && "bg-light-slate-4 "
+          "flex items-center cursor-pointer justify-center flex-1 transition rounded-lg border border-transparent",
+          value === "list" && "bg-light-slate-4"
         )}
       >
+        <span className="sr-only">Contributor list view</span>
         <BsListUl className="text-2xl" />
-      </div>
-      <div
+      </button>
+      <button
+        role="radio"
+        aria-checked={value === "grid"}
+        name="layout"
         onClick={() => handleToggle("grid")}
-        role="toggle"
         className={clsx(
-          "flex items-center justify-center flex-1 rounded-lg transition cursor-pointer",
-          value === "grid" && "bg-light-slate-4 "
+          "flex items-center justify-center flex-1 rounded-lg transition cursor-pointer border border-transparent",
+          value === "grid" && "bg-light-slate-4"
         )}
       >
+        <span className="sr-only">Contributor grid view</span>
         <BiGridAlt className="text-2xl" />
-      </div>
+      </button>
     </div>
   );
 };

--- a/e2e/explore-page.spec.ts
+++ b/e2e/explore-page.spec.ts
@@ -32,6 +32,10 @@ test("Loads explore contributors page", async ({ page }) => {
   await expect(page.getByRole("button", { name: "7d" })).toBeVisible();
   await expect(page.getByRole("button", { name: "30d" })).toBeVisible();
   await expect(page.getByRole("button", { name: "3m" })).toBeVisible();
+
+  await expect(page.getByRole("radio", { name: "Contributor list view" })).toBeVisible();
+  await expect(page.getByRole("radio", { name: "Contributor list view" })).toBeChecked();
+  await expect(page.getByRole("radio", { name: "Contributor grid view" })).toBeVisible();
 });
 
 test("Loads explore activity page", async ({ page }) => {


### PR DESCRIPTION
## Description

Now the grid layout toggle options are radio buttons. I also added some E2E tests for this.

## Related Tickets & Documents

Fixes #3887

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-08-08 at 11 04 18](https://github.com/user-attachments/assets/61d8f829-c7f8-404a-9d12-075457b2230a)

**After**

![CleanShot 2024-08-08 at 11 05 11](https://github.com/user-attachments/assets/dcbbab44-8ea5-4c27-b519-c5ef957f12dc)

## Steps to QA

1. Go to any page with the layout toggle, e.g. `/explore/topic/typescript/contributors/filter/recent?range=30`
2. Use the tab key on the page to tab to the focusable elements on the page. Notice each layout option receives focus now.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/3orifc38YTKGOGBLDq/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
