### PR TITLE
fix: excluded OSCR from old contributor card list component

### DIFF
--- a/components/organisms/ContributorCard/contributor-card.tsx
+++ b/components/organisms/ContributorCard/contributor-card.tsx
@@ -27,10 +27,21 @@ interface ContributorCardProps {
   topic: string;
   repositories?: number[];
   range?: string;
+  // whether to show the OSCR rating or the login button
   showOscr: boolean;
+  // exclude OSCR rating from the card
+  excludeOscr?: boolean;
 }
 
-const ContributorCard = ({ className, contributor, topic, repositories, range, showOscr }: ContributorCardProps) => {
+const ContributorCard = ({
+  className,
+  contributor,
+  topic,
+  repositories,
+  range,
+  showOscr,
+  excludeOscr = false,
+}: ContributorCardProps) => {
   const username = "author_login" in contributor ? contributor.author_login : contributor.login;
   const [showPRs, setShowPRs] = useState(false);
   const githubAvatar = getAvatarByUsername(username);
@@ -59,11 +70,13 @@ const ContributorCard = ({ className, contributor, topic, repositories, range, s
                 <Link href={`/u/${username}`} as={`/u/${username}`}>
                   <Text className="!text-base !text-black">{username}</Text>
                 </Link>
-                <OscrPill
-                  rating={contributor.oscr}
-                  hideRating={!showOscr}
-                  calculated={contributor.devstats_updated_at !== INITIAL_DEV_STATS_TIMESTAMP}
-                />
+                {excludeOscr ? null : (
+                  <OscrPill
+                    rating={contributor.oscr}
+                    hideRating={!showOscr}
+                    calculated={contributor.devstats_updated_at !== INITIAL_DEV_STATS_TIMESTAMP}
+                  />
+                )}
               </div>
               <div className="flex gap-2 text-xs mt-1">
                 <div className="flex items-center gap-1 text-xs text-light-slate-11">

--- a/components/organisms/Contributors/contributors.tsx
+++ b/components/organisms/Contributors/contributors.tsx
@@ -204,6 +204,7 @@ const Contributors = ({
                 topic={topic}
                 repositories={repositories}
                 showOscr={loggedIn}
+                excludeOscr={true}
               />
             ))}
         </div>


### PR DESCRIPTION
## Description

This PR excludes the OSCR score from the contributor card where the data being rendered does not include OSCR. Currently that is workspace repository insight contributor grids, and the explore page contributor grid.

OSCR will land in those two places with the new TanStack table component in the future. See https://github.com/open-sauced/app/issues/3819 

## Related Tickets & Documents

Relates to #3883

## Mobile & Desktop Screenshots/Recordings


## Steps to QA

1. Visit a workspace repository insight contributor page
2. Notice the grid does not include the OSCR scores.
3. Visit the explore contributor page.
4. Notice the grid does not include the OSCR scores.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/hFXwY4lER3oBO/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
