### PR TITLE
chore: Requires the merge queue trigger for enabling merge queue checks

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,6 +1,7 @@
 name: "Compliance"
 
 on:
+  merge_group:
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,6 +1,7 @@
 name: "Development"
 
 on:
+  merge_group:
   pull_request:
     types:
       - opened

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,7 @@ on:
     branches: [main, beta]
   pull_request:
     branches: [main, beta]
+  merge_group:
 env:
   NEXT_PUBLIC_BASE_URL: http://localhost:3000
 jobs:


### PR DESCRIPTION
## Description

These triggers are associated with enabling the merge queue for this repository.

[From the docs:](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)

> If your repository uses GitHub Actions to perform required checks on pull requests in your repository, you need to update the workflows to include the merge_group event as an additional trigger. Otherwise, status checks will not be triggered when you add a pull request to a merge queue. 

## Related Tickets & Documents

N/a - in an attempt to fix the constant back and forth of back merging beta branches

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4