### PR TITLE
chore: Remove merge queue group for compliance checks

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,7 +1,6 @@
 name: "Compliance"
 
 on:
-  merge_group:
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
## Description

Removes the merge queue group from the compliance check: this is PR specific and really only should be able to run on the `pull_request` trigger

## Related Tickets & Documents

Followup to #3906 

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4