### PR TITLE
fix: contributor insight card orange dot no longer squished

### DIFF
--- a/components/molecules/ListCard/list-card.tsx
+++ b/components/molecules/ListCard/list-card.tsx
@@ -29,7 +29,7 @@ const ListCard = ({ list, handleOnDeleteClick, workspaceId, user }: ListCardProp
       <div className="flex flex-col items-start w-full gap-4 px-4 py-6 bg-white rounded-lg md:items-center md:justify-between md:flex-row lg:px-8 lg:gap-2">
         <div className="flex flex-col flex-1 gap-4 lg:gap-6">
           <div className="flex items-center gap-4 lg:items-center ">
-            <div className="w-4 h-4 rounded-full bg-light-orange-10"></div>
+            <div className="w-4 h-4 rounded-full bg-light-orange-10 shrink-0"></div>
             <div className="flex justify-between text-xl text-light-slate-12">
               <Link
                 href={


### PR DESCRIPTION
## Description

Now the contributor insight card orange dot no longer gets squished.

## Related Tickets & Documents

Fixes #3896

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-08-10 at 20 53 21](https://github.com/user-attachments/assets/b1cc9723-def5-44be-b1ab-ed3d580656ee)

**After**

![CleanShot 2024-08-10 at 20 52 44](https://github.com/user-attachments/assets/a26dd3b8-625c-4ff2-81c2-4bcec1a111a3)

## Steps to QA

1. Go to a contributor insight list, e.g. https://deploy-preview-3912--oss-insights.netlify.app/workspaces/21c5e583-f1fd-4033-9ec9-7801f67ff727/contributor-insights
2. Resize the browser window to shrink it.
3. Notice the orange dot no longer gets squished.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/QKSXTlCRK0r1N2NnkV/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
