### PR TITLE
feat: added a link to OSCR tooltips pointing to the OSCR docs

### DIFF
--- a/components/Contributors/Oscr.tsx
+++ b/components/Contributors/Oscr.tsx
@@ -101,7 +101,7 @@ export const OscrInfoTooltip = () => {
           </a>
         </div>
       }
-      className="max-w-xs"
+      className="w-fit max-w-xs !text-sm shadow-lg text-slate-100 !px-4 !py-3 !rounded-xl"
     >
       <HiOutlineInformationCircle className="text-slate-500" />
     </Tooltip>

--- a/components/Contributors/Oscr.tsx
+++ b/components/Contributors/Oscr.tsx
@@ -1,6 +1,7 @@
 import { LockIcon } from "@primer/octicons-react";
 import { usePostHog } from "posthog-js/react";
 import { useRouter } from "next/router";
+import { HiOutlineInformationCircle } from "react-icons/hi";
 import Pill from "components/atoms/Pill/pill";
 import Tooltip from "components/atoms/Tooltip/tooltip";
 import Button from "components/shared/Button/button";
@@ -81,5 +82,28 @@ export const OscrButton = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN, calcu
         <span>{ratingToRender}</span>
       )}
     </>
+  );
+};
+
+export const OscrInfoTooltip = () => {
+  return (
+    <Tooltip
+      content={
+        <div className="grid gap-2">
+          <p>OSCR evaluates the engagement and impact of contributors across the entire open source ecosystem.</p>
+
+          <a
+            href="https://opensauced.pizza/docs/features/contributor-insights/#open-source-contributor-rating-oscr"
+            className="underline"
+          >
+            Learn more...
+            <span className="sr-only"> about OSCR rating</span>
+          </a>
+        </div>
+      }
+      className="max-w-xs"
+    >
+      <HiOutlineInformationCircle className="text-slate-500" />
+    </Tooltip>
   );
 };

--- a/components/Tables/ContributorsTable.tsx
+++ b/components/Tables/ContributorsTable.tsx
@@ -22,7 +22,7 @@ import Avatar from "components/atoms/Avatar/avatar";
 import { getAvatarByUsername } from "lib/utils/github";
 import HoverCardWrapper from "components/molecules/HoverCardWrapper/hover-card-wrapper";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "components/shared/Table";
-import { OscrPill } from "components/Contributors/Oscr";
+import { OscrInfoTooltip, OscrPill } from "components/Contributors/Oscr";
 import { useMediaQuery } from "lib/hooks/useMediaQuery";
 import { setQueryParams } from "lib/utils/query-params";
 import Pagination from "components/molecules/Pagination/pagination";
@@ -212,7 +212,7 @@ const mobileColumns = ({ isLoggedIn }: { isLoggedIn: boolean }) => [
         header: () => (
           <div className="flex gap-2 w-fit items-center">
             <p>OSCR</p>
-            <InfoTooltip information="OSCR evaluates the engagement and impact of contributors across the entire open source ecosystem." />
+            <OscrInfoTooltip />
           </div>
         ),
         enableSorting: true,

--- a/components/atoms/Tooltip/tooltip.tsx
+++ b/components/atoms/Tooltip/tooltip.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 
 interface TooltipProps {
   children: React.ReactNode;
-  content: string;
+  content: React.ReactNode;
   direction?: "top" | "right" | "left" | "bottom";
   delay?: number;
   className?: string;

--- a/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
+++ b/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
@@ -37,8 +37,7 @@ import { DayRangePicker } from "components/shared/DayRangePicker";
 import IssueCommentsTable from "components/Profiles/IssueCommentsTable/issue-comments-table";
 import { contributionsOptions, useContributionsFilter } from "components/Profiles/contributors-sub-tab-list";
 import { SubTabsList } from "components/TabList/tab-list";
-import { OscrButton } from "components/Contributors/Oscr";
-import InfoTooltip from "components/shared/InfoTooltip";
+import { OscrButton, OscrInfoTooltip } from "components/Contributors/Oscr";
 import { INITIAL_DEV_STATS_TIMESTAMP } from "lib/utils/devStats";
 import UserRepositoryRecommendations from "../UserRepositoryRecommendations/user-repository-recommendations";
 
@@ -375,7 +374,7 @@ const ContributorProfileTab = ({
                 <span className="relative text-xs text-light-slate-11 flex gap-0.5 items-center">
                   <span>OSCR Rating</span>
                   <span className="text-sm grid place-content-center">
-                    <InfoTooltip information="OSCR evaluates the engagement and impact of contributors across the entire open source ecosystem." />
+                    <OscrInfoTooltip />
                   </span>
                 </span>
                 <div className="flex mt-1 text-lg md:text-xl lg:text-2xl !text-black leading-none">


### PR DESCRIPTION
## Description

Adds a link to the OSCR docs in OSCR info tooltips.

## Related Tickets & Documents

Closes #3920

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-08-12 at 16 01 14](https://github.com/user-attachments/assets/ba662d40-8a6e-4297-b617-5abc9c89afda)

**After**

![image](https://github.com/user-attachments/assets/9d39c587-0d91-4b45-94e5-ed0ffb722b60)

Note that the after screenshot is using our standard tooltip making it uniform with our other tootips.

## Steps to QA




## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
