### PR TITLE
fix: capture pathname for `OscrButton` when clicked

### DIFF
--- a/components/Contributors/Oscr.tsx
+++ b/components/Contributors/Oscr.tsx
@@ -52,6 +52,7 @@ export const OscrPill = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN, calcula
 };
 
 export const OscrButton = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN, calculated }: OscrProps) => {
+  const router = useRouter();
   const posthog = usePostHog();
   let ratingToRender = calculated ? (rating ? Math.ceil(rating) : 0) : "-";
 
@@ -69,7 +70,9 @@ export const OscrButton = ({ rating, hideRating, signIn = DEFAULT_SIGN_IN, calcu
               variant="primary"
               className="flex items-center gap-2 !p-1 !text-xs z-10"
               onClick={() => {
-                posthog.capture("OSCR Login Button Clicked");
+                posthog.capture("OSCR Login Button Clicked", {
+                  pathname: router.pathname,
+                });
                 signIn({ provider: "github", options: { redirectTo: window.location.href } });
               }}
             >


### PR DESCRIPTION
## Description

Fixes PostHog integration to capture the `OscrButton`'s location (pathname) when clicked by a user to log in.
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents

Fixes #3926

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. Go to anywhere `OscrButton` is used (eg `/u/<username>`)
2. Click the button when logged out
3. Go to PostHog and look for the `OSCR Login Button Clicked` events
4. Ensure the `pathname` is not returned as NULL in the event's properties
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
5. Do this thing
6. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
