### PR TITLE
fix: now the back of the dev card no longer peers through when flipped on Safari and Firefox

### DIFF
--- a/components/molecules/DevCard/dev-card.tsx
+++ b/components/molecules/DevCard/dev-card.tsx
@@ -62,7 +62,7 @@ export default function DevCard(props: DevCardProps) {
 
   return (
     <div
-      className="DevCard"
+      className="DevCard select-none"
       style={{
         width: "245px",
         height: "348px",

--- a/components/molecules/DevCard/dev-card.tsx
+++ b/components/molecules/DevCard/dev-card.tsx
@@ -4,6 +4,7 @@ import Tilt from "react-parallax-tilt";
 import { FiGlobe } from "react-icons/fi";
 import { PiCrownSimpleFill } from "react-icons/pi";
 import { HiArrowNarrowRight, HiTrendingDown, HiTrendingUp } from "react-icons/hi";
+import clsx from "clsx";
 import Button from "components/shared/Button/button";
 import openSaucedImg from "img/openSauced-icon.png";
 import { getRelativeDays } from "lib/utils/date-utils";
@@ -102,7 +103,12 @@ export default function DevCard(props: DevCardProps) {
             height={348}
           />
 
-          <div className="z-10 flex flex-col gap-2 items-center justify-center w-full h-full text-white">
+          <div
+            className={clsx(
+              "z-10 flex flex-col gap-2 items-center justify-center w-full h-full text-white",
+              isFlipped && "invisible"
+            )}
+          >
             {/** Avatar + @Username **/}
             <div className="flex flex-col items-center gap-1">
               <Image


### PR DESCRIPTION
## Description

Te dev card back and front no longer overlap when flipped on Safari and Firefox
## Related Tickets & Documents

Fixes #3927

## Mobile & Desktop Screenshots/Recordings

### Before

**Safari**

![CleanShot 2024-08-12 at 18 33 31](https://github.com/user-attachments/assets/b1422c57-d1af-40bc-9214-8656d06d81d8)

**Firefox**

![CleanShot 2024-08-12 at 18 32 19](https://github.com/user-attachments/assets/7203943e-bf16-4cb3-80fe-25bb28a7aa9b)

**Chromium**

![CleanShot 2024-08-12 at 18 48 26](https://github.com/user-attachments/assets/75c271e4-b836-4ce0-86c2-e637f1cd0e7a)

After

**Safari**

![CleanShot 2024-08-12 at 18 47 37](https://github.com/user-attachments/assets/c3b06167-e577-451b-b5f6-8b62586eb0c1)

**Firefox**

![CleanShot 2024-08-12 at 18 46 40](https://github.com/user-attachments/assets/f9cc11d0-802f-499a-9c9a-5aaf76708df2)

**Chromium**

![CleanShot 2024-08-12 at 18 48 26](https://github.com/user-attachments/assets/ac4c3f11-e569-4ae6-8cbe-2dba2f7554fa)

### Text Selection on Card Flip

I also fixed an issue where the card would get text or images selected within the card.

**Before**

![CleanShot 2024-08-12 at 19 22 37](https://github.com/user-attachments/assets/b26420b5-d52e-4613-b643-a66333735b32)

**After**

![CleanShot 2024-08-12 at 19 27 48](https://github.com/user-attachments/assets/17bcee48-51d0-4f21-b0c8-2e1ae3cbd837)

## Steps to QA

Test the following in a Chromium based browser, Firefox and Safari.

1. Navigate to a dev card page for a user, e.g. https://deploy-preview-3931--oss-insights.netlify.app/u/nickytonline/card
2. Flip the card using the mouse or touch if on mobile.
3. Notice the dev card back and front no longer overlap when flipped


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
