### PR TITLE
feat: now workspace can be generated from repo page via SBOM

### DIFF
--- a/components/Repositories/AddToWorkspaceDrawer.tsx
+++ b/components/Repositories/AddToWorkspaceDrawer.tsx
@@ -12,7 +12,12 @@ import { fetchApiData } from "helpers/fetchApiData";
 import SingleSelect from "components/atoms/Select/single-select";
 import Text from "components/atoms/Typography/text";
 
-export default function AddToWorkspaceDrawer({ repository }: { repository: string }) {
+interface AddToWorkspaceDrawerProps {
+  repository: string;
+  type?: "repo" | "sbom";
+}
+
+export default function AddToWorkspaceDrawer({ repository, type = "repo" }: AddToWorkspaceDrawerProps) {
   const router = useRouter();
   const posthog = usePostHog();
   const { toast } = useToast();
@@ -51,15 +56,38 @@ export default function AddToWorkspaceDrawer({ repository }: { repository: strin
       toast({ description: `Added repository successfully`, variant: "success" });
     }
   };
+
+  const params = new URLSearchParams();
+
+  if (type === "sbom") {
+    params.set("sbom", "true");
+    params.set("repo", repository);
+  } else {
+    params.set("repos", JSON.stringify([repository]));
+  }
+
+  const url = `/workspaces/new?${params}`;
+
+  const redirectTo = new URL(url, window.location.origin).toString();
+
   return (
     <Drawer
       title="Add repository to Workspace"
       description="Create a new workspace or add to an existing one."
       showCloseButton
       trigger={
-        <Button variant="primary" className="shrink-0 items-center gap-3 w-full">
+        <Button
+          variant={type === "repo" ? "primary" : "dark"}
+          className="shrink-0 items-center gap-3 w-full"
+          onClick={(event) => {
+            if (user && type === "sbom") {
+              event.preventDefault();
+              router.push(url);
+            }
+          }}
+        >
           <MdWorkspaces />
-          Add to Workspace
+          {type === "repo" ? "Add to Workspace" : "Workspace from SBOM"}
         </Button>
       }
     >
@@ -76,7 +104,9 @@ export default function AddToWorkspaceDrawer({ repository }: { repository: strin
             lists are now part of your personal workspace.
           </Text>
           <p className="font-medium text-light-orange-10">
-            Create a new workspace with this repository and explore open source like never before!
+            {type === "sbom"
+              ? "Create a new workspace with this repository's SBOM and explore open source like never before!"
+              : "Create a new workspace with this repository and explore open source like never before!"}
           </p>
           <Button
             variant="primary"
@@ -84,7 +114,7 @@ export default function AddToWorkspaceDrawer({ repository }: { repository: strin
             onClick={() => {
               signIn({
                 provider: "github",
-                options: { redirectTo: `${host}/workspaces/new?repos=${JSON.stringify([repository])}` },
+                options: { redirectTo },
               });
             }}
           >

--- a/components/Repositories/AddToWorkspaceDrawer.tsx
+++ b/components/Repositories/AddToWorkspaceDrawer.tsx
@@ -67,12 +67,12 @@ export default function AddToWorkspaceDrawer({ repository, type = "repo" }: AddT
   }
 
   const url = `/workspaces/new?${params}`;
-
   const redirectTo = new URL(url, window.location.origin).toString();
+  const title = type === "repo" ? "Add repository to Workspace" : "Add repository SBOM to Workspace";
 
   return (
     <Drawer
-      title="Add repository to Workspace"
+      title={title}
       description="Create a new workspace or add to an existing one."
       showCloseButton
       trigger={

--- a/components/Repositories/AddToWorkspaceDrawer.tsx
+++ b/components/Repositories/AddToWorkspaceDrawer.tsx
@@ -57,7 +57,7 @@ export default function AddToWorkspaceDrawer({ repository }: { repository: strin
       description="Create a new workspace or add to an existing one."
       showCloseButton
       trigger={
-        <Button variant="primary" className="shrink-0 items-center gap-3 w-fit">
+        <Button variant="primary" className="shrink-0 items-center gap-3 w-full">
           <MdWorkspaces />
           Add to Workspace
         </Button>

--- a/components/Repositories/AddToWorkspaceModal.tsx
+++ b/components/Repositories/AddToWorkspaceModal.tsx
@@ -16,7 +16,7 @@ type AddToWorkspaceModalProps = {
   repository: string;
   isOpen: boolean;
   onCloseModal: () => void;
-  sbomUrl: string;
+  sbomUrl?: string;
 };
 
 export default function AddToWorkspaceModal({ repository, isOpen, onCloseModal, sbomUrl }: AddToWorkspaceModalProps) {

--- a/components/Repositories/AddToWorkspaceModal.tsx
+++ b/components/Repositories/AddToWorkspaceModal.tsx
@@ -26,6 +26,7 @@ export default function AddToWorkspaceModal({ repository, isOpen, onCloseModal, 
   const { signIn, user, sessionToken } = useSupabaseAuth();
   const [workspaceId, setWorkspaceId] = useState("new");
   const { data: workspaces, isLoading: workspacesLoading, mutate } = useWorkspaces({ load: !!user, limit: 100 });
+  const title = sbomUrl ? "Add repository SBOM to Workspace" : "Add repository to Workspace";
 
   const [host, setHost] = useState("");
   useEffect(() => {
@@ -62,7 +63,12 @@ export default function AddToWorkspaceModal({ repository, isOpen, onCloseModal, 
 
   return (
     <Dialog open={isOpen}>
-      <DialogContent autoStyle={false} onEscapeKeyDown={onCloseModal} onInteractOutside={onCloseModal}>
+      <DialogContent
+        aria-label={title}
+        autoStyle={false}
+        onEscapeKeyDown={onCloseModal}
+        onInteractOutside={onCloseModal}
+      >
         <Card heading={<h1 className="text-xl font-semibold">Add to workspace</h1>}>
           <div className="flex flex-col gap-4 w-[32rem] h-full px-8 py-4">
             {!user ? (

--- a/components/Repositories/AddToWorkspaceModal.tsx
+++ b/components/Repositories/AddToWorkspaceModal.tsx
@@ -16,9 +16,10 @@ type AddToWorkspaceModalProps = {
   repository: string;
   isOpen: boolean;
   onCloseModal: () => void;
+  sbomUrl: string;
 };
 
-export default function AddToWorkspaceModal({ repository, isOpen, onCloseModal }: AddToWorkspaceModalProps) {
+export default function AddToWorkspaceModal({ repository, isOpen, onCloseModal, sbomUrl }: AddToWorkspaceModalProps) {
   const { toast } = useToast();
   const router = useRouter();
   const posthog = usePostHog();
@@ -77,7 +78,9 @@ export default function AddToWorkspaceModal({ repository, isOpen, onCloseModal }
                   insights and lists are now part of your personal workspace.
                 </Text>
                 <p className="font-medium text-light-orange-10">
-                  Create a new workspace with this repository and explore open source like never before!
+                  {sbomUrl
+                    ? "Create a new workspace with this repository's SBOM and explore open source like never before!"
+                    : "Create a new workspace with this repository and explore open source like never before!"}
                 </p>
                 <Button
                   variant="primary"
@@ -85,7 +88,9 @@ export default function AddToWorkspaceModal({ repository, isOpen, onCloseModal }
                   onClick={() => {
                     signIn({
                       provider: "github",
-                      options: { redirectTo: `${host}/workspaces/new?repos=${JSON.stringify([repository])}` },
+                      options: {
+                        redirectTo: sbomUrl ? sbomUrl : `${host}/workspaces/new?repos=${JSON.stringify([repository])}`,
+                      },
                     });
                   }}
                 >
@@ -95,28 +100,32 @@ export default function AddToWorkspaceModal({ repository, isOpen, onCloseModal }
               </div>
             ) : (
               <>
-                <p>Create a new workspace or add to an existing one.</p>
-                {workspacesLoading ? (
-                  <p>Loading...</p>
-                ) : (
-                  <SingleSelect
-                    options={[
-                      { label: "Create new workspace...", value: "new" },
-                      ...workspaces.map(({ id, name }) => ({
-                        label: name,
-                        value: id,
-                      })),
-                    ]}
-                    value={workspaceId ?? "new"}
-                    placeholder="Select a workspace"
-                    onValueChange={(value) => {
-                      setWorkspaceId(value);
-                    }}
-                  />
+                {sbomUrl ? null : (
+                  <>
+                    <p>Create a new workspace or add to an existing one.</p>
+                    {workspacesLoading ? (
+                      <p>Loading...</p>
+                    ) : (
+                      <SingleSelect
+                        options={[
+                          { label: "Create new workspace...", value: "new" },
+                          ...workspaces.map(({ id, name }) => ({
+                            label: name,
+                            value: id,
+                          })),
+                        ]}
+                        value={workspaceId ?? "new"}
+                        placeholder="Select a workspace"
+                        onValueChange={(value) => {
+                          setWorkspaceId(value);
+                        }}
+                      />
+                    )}
+                    <Button onClick={addRepositoryToWorkspace} variant="primary" className="w-fit self-end">
+                      Confirm
+                    </Button>
+                  </>
                 )}
-                <Button onClick={addRepositoryToWorkspace} variant="primary" className="w-fit self-end">
-                  Confirm
-                </Button>
               </>
             )}
           </div>

--- a/components/Workspaces/TrackedReposTable.tsx
+++ b/components/Workspaces/TrackedReposTable.tsx
@@ -2,6 +2,7 @@ import { BiBarChartAlt2 } from "react-icons/bi";
 import { FaPlus } from "react-icons/fa6";
 import { FaTrashAlt } from "react-icons/fa";
 import { ComponentProps } from "react";
+import { MdWorkspaces } from "react-icons/md";
 import Button from "components/shared/Button/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "components/shared/Table";
 import { Avatar } from "components/atoms/Avatar/avatar-hover-card";
@@ -13,6 +14,7 @@ interface TrackedReposTableProps {
   onAddRepos: () => void;
   onRemoveTrackedRepo: ComponentProps<"button">["onClick"];
   isLoading?: boolean;
+  loadingMessage?: string;
   disabled?: boolean;
 }
 
@@ -53,10 +55,11 @@ export const TrackedReposTable = ({
   onAddRepos,
   onRemoveTrackedRepo,
   isLoading = false,
+  loadingMessage,
   disabled = false,
 }: TrackedReposTableProps) => {
   return (
-    <div className="grid gap-4">
+    <div className="grid gap-4" aria-busy={isLoading} aria-live="polite">
       <div className="flex justify-between flex-wrap gap-2">
         <div>
           <h2 className="flex gap-1 font-medium mb-2 text-md">Repositories Tracked</h2>
@@ -80,7 +83,7 @@ export const TrackedReposTable = ({
         </Table>
         <ClientOnly>
           {repositories.size > 0 || isLoading ? (
-            <div className="overflow-y-scroll h-60">
+            <div className="relative overflow-y-scroll h-60">
               <Table>
                 <TableHeader className="sr-only">
                   <TableRow className=" bg-light-slate-3">
@@ -116,6 +119,14 @@ export const TrackedReposTable = ({
                   )}
                 </TableBody>
               </Table>
+              {isLoading && loadingMessage ? (
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="flex gap-2 items-center z-1 text-lg border border-light-slate-7 rounded-lg bg-light-slate-3 p-4">
+                    <MdWorkspaces />
+                    {loadingMessage}
+                  </div>
+                </div>
+              ) : null}
             </div>
           ) : (
             <EmptyState onAddRepos={onAddRepos} disabled={disabled} />

--- a/e2e/repo-page.spec.ts
+++ b/e2e/repo-page.spec.ts
@@ -9,13 +9,65 @@ test("Loads a repository page", async ({ page }) => {
   await expect(rangePopup).toBeVisible();
   await expect(rangePopup).toHaveAttribute("aria-haspopup", "menu");
   await expect(rangePopup).toHaveAttribute("data-state", "closed");
-});
 
-test("repository page has an OG image", async ({ page }) => {
-  await page.goto("/s/open-sauced/app");
+  page.getByRole("button", { name: "Add to Workspace", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Workspace from SBOM", exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Share", exact: true })).toBeVisible();
+
+  // check for OG image
   const expectedUrl = `${config.use?.baseURL}/og-images/repository/open-sauced/app/30?description=%F0%9F%8D%95+Insights+into+your+entire+open+source+ecosystem.`;
 
   await expect(page.locator('meta[property="og:image"]')).toHaveAttribute("content", expectedUrl);
   await expect(page.locator('meta[name="twitter:image"]')).toHaveAttribute("content", expectedUrl);
   await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute("content", "summary_large_image");
+});
+
+test.describe("large screen", () => {
+  test("Adds a repository to a workspace", async ({ page }) => {
+    await page.goto("/s/open-sauced/app");
+
+    await page.getByRole("button", { name: "Add to Workspace", exact: true }).click();
+    const dialog = await page.getByRole("dialog", { name: "Add repository to Workspace", exact: true });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole("button", { name: "Connect with GitHub", exact: true }).click();
+    await expect(page.url()).toContain("https://github.com/login");
+  });
+
+  test("Adds a repository SBOM to a workspace", async ({ page }) => {
+    await page.goto("/s/open-sauced/app");
+
+    await page.getByRole("button", { name: "Workspace from SBOM", exact: true }).click();
+    const dialog = await page.getByRole("dialog", { name: "Add repository SBOM to Workspace", exact: true });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole("button", { name: "Connect with GitHub", exact: true }).click();
+    await expect(page.url()).toContain("https://github.com/login");
+  });
+});
+
+test.describe("small screen", () => {
+  test.use({ viewport: { width: 375, height: 629 } });
+
+  test("Adds a repository to a workspace", async ({ page }) => {
+    await page.goto("/s/open-sauced/app");
+
+    await page.getByRole("button", { name: "Add to Workspace", exact: true }).click();
+    const dialog = await page.getByRole("dialog", { name: "Add repository to Workspace", exact: true });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole("button", { name: "Connect with GitHub", exact: true }).click();
+    await expect(page.url()).toContain("https://github.com/login");
+  });
+
+  test("Adds a repository SBOM to a workspace", async ({ page }) => {
+    await page.goto("/s/open-sauced/app");
+
+    await page.getByRole("button", { name: "Workspace from SBOM", exact: true }).click();
+    const dialog = await page.getByRole("dialog", { name: "Add repository SBOM to Workspace", exact: true });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole("button", { name: "Connect with GitHub", exact: true }).click();
+    await expect(page.url()).toContain("https://github.com/login");
+  });
 });

--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -44,6 +44,7 @@ import YoloChart from "components/Repositories/YoloChart";
 import LanguagePill, { getLanguageTopic } from "components/shared/LanguagePill/LanguagePill";
 import OssfChart from "components/Repositories/OssfChart";
 import { setQueryParams } from "lib/utils/query-params";
+import Tooltip from "components/atoms/Tooltip/tooltip";
 
 const AddToWorkspaceModal = dynamic(() => import("components/Repositories/AddToWorkspaceModal"), {
   ssr: false,
@@ -244,7 +245,7 @@ export default function RepoPage({ repoData, ogImageUrl }: RepoPageProps) {
                     <AddToWorkspaceDrawer type="sbom" repository={repoData.full_name} />
                   </>
                 ) : (
-                  <>
+                  <div className="grid gap-2 md:gap-1 w-fit">
                     <Button
                       variant="primary"
                       onClick={() => {
@@ -256,33 +257,45 @@ export default function RepoPage({ repoData, ogImageUrl }: RepoPageProps) {
                       <MdWorkspaces />
                       Add to Workspace
                     </Button>
-                    <Button
-                      variant="dark"
-                      onClick={() => {
-                        posthog.capture("Repo Pages: clicked 'Create Workspace from SBOM'", {
-                          repository: repoData.full_name,
-                        });
+                    <Tooltip
+                      content={
+                        <div className="grid gap-2">
+                          <p>Create a workspace from the software bill of materials (SBOM) for this repository</p>
 
-                        const params = new URLSearchParams();
-                        params.set("sbom", "true");
-                        params.set("repo", repoData.full_name);
-
-                        const url = `/workspaces/new?${params}`;
-
-                        if (!session) {
-                          setSbomUrl(new URL(url, window.location.origin).toString());
-                          setIsAddToWorkspaceModalOpen(true);
-                          return;
-                        }
-
-                        router.push(url);
-                      }}
-                      className="shrink-0 items-center gap-3 w-full"
+                          <a href="https://www.cisa.gov/sbom" className="underline" target="_blank">
+                            Learn more...<span className="sr-only"> about SBOM</span>
+                          </a>
+                        </div>
+                      }
                     >
-                      <MdWorkspaces />
-                      Workspace from SBOM
-                    </Button>
-                  </>
+                      <Button
+                        variant="dark"
+                        onClick={() => {
+                          posthog.capture("Repo Pages: clicked 'Create Workspace from SBOM'", {
+                            repository: repoData.full_name,
+                          });
+
+                          const params = new URLSearchParams();
+                          params.set("sbom", "true");
+                          params.set("repo", repoData.full_name);
+
+                          const url = `/workspaces/new?${params}`;
+
+                          if (!session) {
+                            setSbomUrl(new URL(url, window.location.origin).toString());
+                            setIsAddToWorkspaceModalOpen(true);
+                            return;
+                          }
+
+                          router.push(url);
+                        }}
+                        className="shrink-0 items-center gap-3 w-full"
+                      >
+                        <MdWorkspaces />
+                        Workspace from SBOM
+                      </Button>
+                    </Tooltip>
+                  </div>
                 )}
                 <div className="flex gap-2 items-center">
                   <Button

--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -240,17 +240,39 @@ export default function RepoPage({ repoData, ogImageUrl }: RepoPageProps) {
                 {isMobile ? (
                   <AddToWorkspaceDrawer repository={repoData.full_name} />
                 ) : (
-                  <Button
-                    variant="primary"
-                    onClick={() => {
-                      posthog.capture("Repo Pages: clicked 'Add to Workspace'", { repository: repoData.full_name });
-                      setIsAddToWorkspaceModalOpen(true);
-                    }}
-                    className="shrink-0 items-center gap-3 w-fit"
-                  >
-                    <MdWorkspaces />
-                    Add to Workspace
-                  </Button>
+                  <>
+                    <Button
+                      variant="primary"
+                      onClick={() => {
+                        posthog.capture("Repo Pages: clicked 'Add to Workspace'", { repository: repoData.full_name });
+                        setIsAddToWorkspaceModalOpen(true);
+                      }}
+                      className="shrink-0 items-center gap-3 w-full"
+                    >
+                      <MdWorkspaces />
+                      Add to Workspace
+                    </Button>
+                    <Button
+                      variant="primary"
+                      onClick={() => {
+                        posthog.capture("Repo Pages: clicked 'Create Workspace from SBOM'", {
+                          repository: repoData.full_name,
+                        });
+
+                        // use urlsearchapi to update the url
+                        // sbom=true&repo=${encodeURIComponent(repoData.full_name)}
+                        const params = new URLSearchParams();
+                        params.set("sbom", "true");
+                        params.set("repo", repoData.full_name);
+
+                        router.push(`/workspaces/new?${params}`);
+                      }}
+                      className="shrink-0 items-center gap-3 w-full"
+                    >
+                      <MdWorkspaces />
+                      Workspace from SBOM
+                    </Button>
+                  </>
                 )}
                 <div className="flex gap-2 items-center">
                   <Button

--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -215,6 +215,27 @@ export default function RepoPage({ repoData, ogImageUrl }: RepoPageProps) {
     }
   };
 
+  const workspaceFromSbomButton = (
+    <Button
+      variant="primary"
+      onClick={() => {
+        posthog.capture("Repo Pages: clicked 'Create Workspace from SBOM'", {
+          repository: repoData.full_name,
+        });
+
+        const params = new URLSearchParams();
+        params.set("sbom", "true");
+        params.set("repo", repoData.full_name);
+
+        router.push(`/workspaces/new?${params}`);
+      }}
+      className="shrink-0 items-center gap-3 w-full"
+    >
+      <MdWorkspaces />
+      Workspace from SBOM
+    </Button>
+  );
+
   return (
     <>
       <RepositoryOgImage repository={repoData} ogImageUrl={ogImageUrl} />
@@ -238,7 +259,10 @@ export default function RepoPage({ repoData, ogImageUrl }: RepoPageProps) {
               </header>
               <div className="self-end flex flex-col gap-2 items-end">
                 {isMobile ? (
-                  <AddToWorkspaceDrawer repository={repoData.full_name} />
+                  <>
+                    <AddToWorkspaceDrawer repository={repoData.full_name} />
+                    {workspaceFromSbomButton}
+                  </>
                 ) : (
                   <>
                     <Button
@@ -252,24 +276,7 @@ export default function RepoPage({ repoData, ogImageUrl }: RepoPageProps) {
                       <MdWorkspaces />
                       Add to Workspace
                     </Button>
-                    <Button
-                      variant="primary"
-                      onClick={() => {
-                        posthog.capture("Repo Pages: clicked 'Create Workspace from SBOM'", {
-                          repository: repoData.full_name,
-                        });
-
-                        const params = new URLSearchParams();
-                        params.set("sbom", "true");
-                        params.set("repo", repoData.full_name);
-
-                        router.push(`/workspaces/new?${params}`);
-                      }}
-                      className="shrink-0 items-center gap-3 w-full"
-                    >
-                      <MdWorkspaces />
-                      Workspace from SBOM
-                    </Button>
+                    {workspaceFromSbomButton}
                   </>
                 )}
                 <div className="flex gap-2 items-center">

--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -256,7 +256,7 @@ export default function RepoPage({ repoData, ogImageUrl }: RepoPageProps) {
                       Add to Workspace
                     </Button>
                     <Button
-                      variant="primary"
+                      variant="dark"
                       onClick={() => {
                         posthog.capture("Repo Pages: clicked 'Create Workspace from SBOM'", {
                           repository: repoData.full_name,

--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -241,6 +241,7 @@ export default function RepoPage({ repoData, ogImageUrl }: RepoPageProps) {
                 {isMobile ? (
                   <>
                     <AddToWorkspaceDrawer repository={repoData.full_name} />
+                    <AddToWorkspaceDrawer type="sbom" repository={repoData.full_name} />
                   </>
                 ) : (
                   <>

--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -494,7 +494,6 @@ export default function RepoPage({ repoData, ogImageUrl }: RepoPageProps) {
 
       <AddToWorkspaceModal
         sbomUrl={sbomUrl}
-        content="Create a new workspace from the SBOM for this repository"
         repository={repoData.full_name}
         isOpen={isAddToWorkspaceModalOpen}
         onCloseModal={() => setIsAddToWorkspaceModalOpen(false)}

--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -259,8 +259,6 @@ export default function RepoPage({ repoData, ogImageUrl }: RepoPageProps) {
                           repository: repoData.full_name,
                         });
 
-                        // use urlsearchapi to update the url
-                        // sbom=true&repo=${encodeURIComponent(repoData.full_name)}
                         const params = new URLSearchParams();
                         params.set("sbom", "true");
                         params.set("repo", repoData.full_name);


### PR DESCRIPTION
## Description

Now you can generate a workspace via a repository page based on the repository's [software bill of materials](https://github.blog/enterprise-software/governance-and-compliance/introducing-self-service-sboms/) (SBOM).

Analytics also get sent to PostHog when someone clicks the <kbd>Workspace from SBOM</kbd> button.

Note that @jpmcb is working on SBOM for Go, but that does not block this PR. Once his stuff lands, it'll no longer report that a Go project isn't supported.

Until we have documentation, I'm linking directly to the https://www.cisa.gov/sbom page in the SBOM button tooltip.

## Related Tickets & Documents

Closes #3842
Relates to https://github.com/open-sauced/api/issues/1027

## Mobile & Desktop Screenshots/Recordings

The buttons are different colours now as mentioned in the comments below. Dropping a screenshot here as the video isn't up to date.

![CleanShot 2024-08-13 at 16 15 00](https://github.com/user-attachments/assets/0c332388-40b0-4869-8ca1-fcfdb12b5227)


https://github.com/user-attachments/assets/33c37504-e3a3-4935-b680-1008db3a1584

## Steps to QA

1. Go to a repository page, e.g. https://deploy-preview-3938--oss-insights.netlify.app/s/microsoft/playwright
2. Click on the <kbd>Workspace from SBOM</kbd> in the top right of the repository page.
3. You're redirected to the new workspace page.
4. The name of the workspace is pre-populated with the following text, `SBOM for some-org/some-repo`, e.g. `SBOM for microsoft/playwright`.
5. The tracked repos table is in a loading state.
6. Once the SBOM call is completed, the list of repositories is populated in the grid and the loading message disappears.
7. Click on the <kbd>Create workspace</kbd> button.
8. You're redirected to the workspace overview.

**Note that sometimes it can take a while for the SBOM API call to complete.**


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [x] Tier 3
- [ ] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
