### PR TITLE
fix: now see it now link on feed when logged in goes to the user's dev card

### DIFF
--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -209,7 +209,7 @@ export default function Feeds(props: HighlightSSRProps) {
                   "Discover your open source impact with the OSCR - Open Source Contributor Rating. Visit your profile to view your personalized DevCard, showcasing your influence and impact on the open source ecosystem. Check out your OSCR DevCard and share it today!"
                 }
                 bannerSrc={"/assets/images/anouncement-cards/OSCR-devcard.png"}
-                url={`/u/${loggedInUser?.name ? loggedInUser.name + "/card" : "bdougie/card"}`}
+                url={`/u/${loggedInUser?.login ? loggedInUser.login + "/card" : "bdougie/card"}`}
                 cta={"See It Now!"}
               />
             </div>


### PR DESCRIPTION
## Description

Now when logged in, the "See it now" link on the feed page goes to the user's dev card.

## Related Tickets & Documents

Fixes #3952

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. Go to the feed page logged in, `/feed`.
2. Click on the See it now link in the OSCR panel.
3. You're redirected to your dev card page.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/NVBR6cLvUjV9C/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
