### PR TITLE
fix: add tooltip for long titles

### DIFF
--- a/components/atoms/Select/single-select.tsx
+++ b/components/atoms/Select/single-select.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useRef, useState } from "react";
 import { RiArrowDownSLine } from "react-icons/ri";
-import * as Tooltip from "@radix-ui/react-tooltip";
+
 import clsx from "clsx";
 
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from "@radix-ui/react-dropdown-menu";
 import { Command, CommandGroup, CommandInput, CommandItem } from "../Cmd/command";
-
+import Tooltip from "../Tooltip/tooltip";
 interface SingleSelectProps {
   value?: string;
   onValueChange: (value: string) => void;
@@ -45,20 +45,6 @@ const SingleSelect = ({
       });
     }
   }, [isOpen, isSearchable]);
-  const truncateLabel = (label: string, wordLimit: number, maxChars: number) => {
-    const words = label.split(" ");
-    let truncated = label;
-    if (words.length > wordLimit) {
-      truncated = words.slice(0, wordLimit).join(" ") + "...";
-    }
-    if (truncated.length > maxChars) {
-      truncated = truncated.slice(0, maxChars - 3) + "...";
-    }
-    return truncated;
-  };
-  const label = current?.label || placeholder || "";
-  const truncatedLabel = truncateLabel(label, 4, 23);
-  const isTruncated = label.length > truncatedLabel.length;
 
   return (
     <DropdownMenu
@@ -77,26 +63,11 @@ const SingleSelect = ({
           insetLabel && `before:content-[attr(data-inset-label)] before:mr-1 before:font-normal before:text-slate-500`
         )}
       >
-        {isTruncated ? (
-          <Tooltip.Provider>
-            <Tooltip.Root>
-              <Tooltip.Trigger asChild>
-                <p className="grow text-start truncate">{truncatedLabel}</p>
-              </Tooltip.Trigger>
-              <Tooltip.Content
-                className="text-black p-3 rounded-lg shadow-lg border border-gray-300"
-                side="bottom"
-                align="center"
-                style={{ backgroundColor: "#fafafa" }}
-              >
-                {label}
-                <Tooltip.Arrow className="fill-gray-300" />
-              </Tooltip.Content>
-            </Tooltip.Root>
-          </Tooltip.Provider>
-        ) : (
-          <p className="grow text-start">{label}</p>
-        )}
+        <Tooltip content={current?.label ?? placeholder}>
+          <div className="flex items-center w-[200px]">
+            <p className="flex-grow text-start truncate">{current?.label ?? placeholder}</p>
+          </div>
+        </Tooltip>
 
         <div className="flex items-center">
           <RiArrowDownSLine size={20} className="w-5 text-slate-400" />

--- a/components/atoms/Select/single-select.tsx
+++ b/components/atoms/Select/single-select.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { RiArrowDownSLine } from "react-icons/ri";
-
+import * as Tooltip from "@radix-ui/react-tooltip";
 import clsx from "clsx";
 
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent } from "@radix-ui/react-dropdown-menu";
@@ -45,6 +45,20 @@ const SingleSelect = ({
       });
     }
   }, [isOpen, isSearchable]);
+  const truncateLabel = (label: string, wordLimit: number, maxChars: number) => {
+    const words = label.split(" ");
+    let truncated = label;
+    if (words.length > wordLimit) {
+      truncated = words.slice(0, wordLimit).join(" ") + "...";
+    }
+    if (truncated.length > maxChars) {
+      truncated = truncated.slice(0, maxChars - 3) + "...";
+    }
+    return truncated;
+  };
+  const label = current?.label || placeholder || "";
+  const truncatedLabel = truncateLabel(label, 4, 23);
+  const isTruncated = label.length > truncatedLabel.length;
 
   return (
     <DropdownMenu
@@ -63,7 +77,27 @@ const SingleSelect = ({
           insetLabel && `before:content-[attr(data-inset-label)] before:mr-1 before:font-normal before:text-slate-500`
         )}
       >
-        <p className="grow text-start">{current?.label ?? placeholder}</p>
+        {isTruncated ? (
+          <Tooltip.Provider>
+            <Tooltip.Root>
+              <Tooltip.Trigger asChild>
+                <p className="grow text-start truncate">{truncatedLabel}</p>
+              </Tooltip.Trigger>
+              <Tooltip.Content
+                className="text-black p-3 rounded-lg shadow-lg border border-gray-300"
+                side="bottom"
+                align="center"
+                style={{ backgroundColor: "#fafafa" }}
+              >
+                {label}
+                <Tooltip.Arrow className="fill-gray-300" />
+              </Tooltip.Content>
+            </Tooltip.Root>
+          </Tooltip.Provider>
+        ) : (
+          <p className="grow text-start">{label}</p>
+        )}
+
         <div className="flex items-center">
           <RiArrowDownSLine size={20} className="w-5 text-slate-400" />
         </div>

--- a/components/atoms/Select/single-select.tsx
+++ b/components/atoms/Select/single-select.tsx
@@ -64,7 +64,7 @@ const SingleSelect = ({
         )}
       >
         <Tooltip content={current?.label ?? placeholder}>
-          <div className="flex items-center w-[200px]">
+          <div className="flex items-center w-48">
             <p className="flex-grow text-start truncate">{current?.label ?? placeholder}</p>
           </div>
         </Tooltip>


### PR DESCRIPTION
## Description

Fixes #3673

This pull request fixes the issue where a long title would overflow from the side drawer. Now, the PR includes truncated labels for long titles, with the full label shown in a tooltip upon hovering. 


## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
This PR fixes issue #3673
## Mobile & Desktop Screenshots/Recordings

[screen-capture (21).webm](https://github.com/user-attachments/assets/daba5015-5958-4acc-ac41-9cf5a0ec9952)

<!-- Visual changes require screenshots -->


## Steps to QA
Test cases were not added as I didn't find the corresponding test file for this component. Should I write it from scratch?
1. Go to workspace
2. Create new workspace with a long name
3. See the truncated title and tooltip upon hovering



## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
