### PR TITLE
fix: make timezone optional for onboarding and user settings

### DIFF
--- a/components/organisms/UserSettingsPage/user-settings-page.tsx
+++ b/components/organisms/UserSettingsPage/user-settings-page.tsx
@@ -340,8 +340,8 @@ const UserSettingsPage = ({ user }: UserSettingsPageProps) => {
 
             <div id="upgrade" className="flex flex-col gap-2">
               <label className="flex flex-col w-full gap-2">
-                Time zone*
-                <Select onValueChange={(value) => setTimezone(value)} value={timezone} required>
+                Time zone
+                <Select onValueChange={(value) => setTimezone(value)} value={timezone}>
                   <SelectTrigger
                     selectIcon={
                       <div className="relative pr-4">
@@ -354,6 +354,7 @@ const UserSettingsPage = ({ user }: UserSettingsPageProps) => {
                   </SelectTrigger>
 
                   <SelectContent position="item-aligned" className="bg-white">
+                    <SelectItem value={""}>Select timezone</SelectItem>
                     {timezones.map((timezone, index) => (
                       <SelectItem key={`timezone_${index}`} value={timezone.value}>
                         {timezone.text}

--- a/pages/start.tsx
+++ b/pages/start.tsx
@@ -34,6 +34,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "c
 import { timezones } from "lib/utils/timezones";
 import { useFetchUser } from "lib/hooks/useFetchUser";
 import { useFetchUserDevStats } from "lib/hooks/api/useFetchUserDevStats";
+import { copyImageToClipboard } from "lib/utils/copy-to-clipboard";
+import { toast } from "lib/hooks/useToast";
+import { siteUrl } from "lib/utils/urls";
 
 type StepKeys = "1" | "2" | "3";
 
@@ -283,10 +286,20 @@ const LoginStep3: React.FC<LoginStep3Props> = ({ user }) => {
 
           <Button
             variant="primary"
-            onClick={() => router.push(`/u/${username}/card`)}
+            onClick={() =>
+              copyImageToClipboard(siteUrl(`og-images/dev-card`, { username })).then((copied) => {
+                if (copied) {
+                  setTimeout(() => {
+                    toast({ description: "Copied to clipboard", variant: "success" });
+                  }, 500);
+                } else {
+                  toast({ description: "Error copying to clipboard", variant: "warning" });
+                }
+              })
+            }
             className="justify-center w-full mt-4"
           >
-            Go to Your DevCard
+            Share Your DevCard
           </Button>
 
           <Button

--- a/pages/start.tsx
+++ b/pages/start.tsx
@@ -150,15 +150,7 @@ const LoginStep2: React.FC<LoginStep2Props> = ({ user }) => {
   const [timezone, setTimezone] = useState("");
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const timezone = timezones.find((timezone) => timezone.utc.includes(userTimezone));
-    if (timezone) {
-      setTimezone(timezone.value);
-    }
-  }, []);
-
-  const handleUpdateTimezone = async () => {
+  const handleOnboarding = async (updateTimezone: boolean) => {
     setLoading(true);
     try {
       const data = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/onboarding`, {
@@ -167,7 +159,7 @@ const LoginStep2: React.FC<LoginStep2Props> = ({ user }) => {
           "Content-Type": "application/json",
           Authorization: `Bearer ${sessionToken}`,
         },
-        body: JSON.stringify({ interests: [], timezone }),
+        body: JSON.stringify({ interests: [], timezone: updateTimezone ? timezone : "" }),
       });
 
       if (data.ok) {
@@ -203,8 +195,7 @@ const LoginStep2: React.FC<LoginStep2Props> = ({ user }) => {
           </div>
 
           <div className="flex flex-col gap-2">
-            <label>Time zone*</label>
-            <Select onValueChange={(value) => setTimezone(value)} value={timezone} required>
+            <Select onValueChange={(value) => setTimezone(value)} value={timezone}>
               <SelectTrigger
                 selectIcon={
                   <div className="relative pr-4">
@@ -217,6 +208,7 @@ const LoginStep2: React.FC<LoginStep2Props> = ({ user }) => {
               </SelectTrigger>
 
               <SelectContent position="item-aligned" className="bg-white">
+                <SelectItem value={""}>Select timezone</SelectItem>
                 {timezones.map((timezone, index) => (
                   <SelectItem key={index} value={timezone.value}>
                     {timezone.text}
@@ -225,16 +217,26 @@ const LoginStep2: React.FC<LoginStep2Props> = ({ user }) => {
               </SelectContent>
             </Select>
           </div>
+          <Button
+            variant="primary"
+            onClick={() => handleOnboarding(true)}
+            className="justify-center w-full mt-4"
+            disabled={loading}
+            loading={loading}
+          >
+            Continue
+          </Button>
+
+          <Button
+            variant="primary"
+            onClick={() => handleOnboarding(false)}
+            className="justify-center w-full mt-4"
+            disabled={loading}
+            loading={loading}
+          >
+            Skip
+          </Button>
         </div>
-        <Button
-          variant="primary"
-          onClick={handleUpdateTimezone}
-          className="justify-center w-full h-10 mt-3 md:mt-0"
-          disabled={loading || !timezone}
-          loading={loading}
-        >
-          Continue
-        </Button>
       </div>
     </>
   );


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
Makes timezone selection optional when onboarding or updating user settings

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Closes #3971

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

![image](https://github.com/user-attachments/assets/76549025-8682-42f2-b6fa-47bd959091e6)


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/odOvbqyB5fNVZRPtjK/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
