### PR TITLE
feat: implement the CopyContainer component for copying it's contents as an image

### DIFF
--- a/components/shared/CopyContainer.stories.tsx
+++ b/components/shared/CopyContainer.stories.tsx
@@ -1,0 +1,30 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { Toaster } from "components/molecules/Toaster/toaster";
+import { CopyContainer } from "./CopyContainer";
+
+type Story = StoryObj<typeof CopyContainer>;
+
+const meta: Meta<typeof CopyContainer> = {
+  title: "Components/Shared/CopyContainer",
+  component: CopyContainer,
+  args: {
+    children: <p className="p-4 rounded-md bg-black text-white">Hello world</p>,
+  },
+  decorators: [
+    (Story) => (
+      <>
+        <Toaster />
+        <div className="p-8 grid gap-2">
+          <p>
+            Hover over the text and notice the copy button at the top right. Press it to copy the markup as an image.
+          </p>
+          <Story />
+        </div>
+      </>
+    ),
+  ],
+};
+
+export default meta;
+
+export const Default: Story = {};

--- a/components/shared/CopyContainer.tsx
+++ b/components/shared/CopyContainer.tsx
@@ -1,0 +1,49 @@
+import { CopyIcon } from "@primer/octicons-react";
+import { useRef, useState } from "react";
+import { Options } from "html2canvas";
+import { Spinner } from "components/atoms/SpinLoader/spin-loader";
+import { useToast } from "lib/hooks/useToast";
+import { copyNodeAsImage } from "lib/utils/copy-to-clipboard";
+
+interface CopyContainerProps {
+  copySuccessMessage?: string;
+  copyErrorMessage?: string;
+  options?: Partial<Options>;
+  children: React.ReactNode;
+}
+
+export const CopyContainer = ({
+  copySuccessMessage = "Copied image to clipboard",
+  copyErrorMessage = "Error copying image",
+  options,
+  children,
+}: CopyContainerProps) => {
+  const { toast } = useToast();
+  const copyRef = useRef<HTMLDivElement>(null);
+  const [processing, setProcessing] = useState(false);
+
+  return (
+    <div className="relative group" aria-busy={processing}>
+      <button
+        className="absolute top-2 right-2 p-2 bg-white rounded-md shadow-md opacity-0 group-hover:opacity-100 focus-within:opacity-100 scale-95 group-hover:scale-100 transition-all duration-200 ease-in-out transform"
+        onClick={async () => {
+          const node = copyRef.current;
+
+          try {
+            setProcessing(true);
+            await copyNodeAsImage(node, options);
+            toast({ description: copySuccessMessage, variant: "success" });
+          } catch (error) {
+            toast({ description: copyErrorMessage, variant: "danger" });
+          } finally {
+            setProcessing(false);
+          }
+        }}
+      >
+        <span className="sr-only">Copy</span>
+        {processing ? <Spinner className="text-slate-800 w-4 h-4" /> : <CopyIcon className="text-slate-800 w-4 h-4" />}
+      </button>
+      <span ref={copyRef}>{children}</span>
+    </div>
+  );
+};

--- a/lib/utils/copy-to-clipboard.ts
+++ b/lib/utils/copy-to-clipboard.ts
@@ -1,4 +1,4 @@
-import html2canvas from "html2canvas";
+import html2canvas, { Options } from "html2canvas";
 import { shortenUrl } from "./shorten-url";
 
 export const copyToClipboard = async (content: string) => {
@@ -33,10 +33,11 @@ export async function copyImageToClipboard(imageUrl: string) {
  * Copies the content of an HTML element as an image to the clipboard.
  *
  * @param node The HTML element to copy as an image.
+ * @param options The options to tweak the image generation.
  *
  * @returns A promise that resolves when the image has been copied to the clipboard.
  */
-export async function copyNodeAsImage(node: HTMLElement | null) {
+export async function copyNodeAsImage(node: HTMLElement | null, options?: Partial<Options>) {
   if (!node) {
     throw new Error("Failed to copy image to clipboard");
   }
@@ -44,7 +45,7 @@ export async function copyNodeAsImage(node: HTMLElement | null) {
   await navigator.clipboard.write([
     new ClipboardItem({
       "image/png": new Promise(async (resolve, reject) => {
-        html2canvas(node).then((canvas) => {
+        html2canvas(node, options).then((canvas) => {
           canvas.toBlob((blob) => {
             if (!blob) {
               reject("Failed to copy image to clipboard");

--- a/pages/s/[org]/[repo]/index.tsx
+++ b/pages/s/[org]/[repo]/index.tsx
@@ -45,6 +45,7 @@ import LanguagePill, { getLanguageTopic } from "components/shared/LanguagePill/L
 import OssfChart from "components/Repositories/OssfChart";
 import { setQueryParams } from "lib/utils/query-params";
 import Tooltip from "components/atoms/Tooltip/tooltip";
+import { CopyContainer } from "components/shared/CopyContainer";
 
 const AddToWorkspaceModal = dynamic(() => import("components/Repositories/AddToWorkspaceModal"), {
   ssr: false,
@@ -356,25 +357,37 @@ export default function RepoPage({ repoData, ogImageUrl }: RepoPageProps) {
               <section className="flex flex-col gap-4 lg:grid lg:grid-cols-12 lg:max-h-[50rem]">
                 <div className="lg:col-span-8 flex flex-col gap-4">
                   <div className="flex gap-4 h-full flex-col lg:flex-row">
-                    <ContributorConfidenceChart
-                      contributorConfidence={repoStats?.contributor_confidence}
-                      isError={isError}
-                      isLoading={isLoading}
-                      onLearnMoreClick={() =>
-                        posthog.capture("Repo Pages: clicked Contributor Confidence docs", {
-                          repository: repoData.full_name,
-                        })
-                      }
-                    />
-                    <OssfChart
-                      repository={repoData.full_name}
-                      totalScore={repoData.ossf_scorecard_total_score}
-                      dependencyUpdateScore={repoData.ossf_scorecard_dependency_update_score}
-                      maintainedScore={repoData.ossf_scorecard_maintained_score}
-                      fuzzingScore={repoData.ossf_scorecard_fuzzing_score}
-                      isLoading={false}
-                      isError={!repoData.ossf_scorecard_total_score}
-                    />
+                    <CopyContainer
+                      options={{
+                        windowWidth: 1700,
+                      }}
+                    >
+                      <ContributorConfidenceChart
+                        contributorConfidence={repoStats?.contributor_confidence}
+                        isError={isError}
+                        isLoading={isLoading}
+                        onLearnMoreClick={() =>
+                          posthog.capture("Repo Pages: clicked Contributor Confidence docs", {
+                            repository: repoData.full_name,
+                          })
+                        }
+                      />
+                    </CopyContainer>
+                    <CopyContainer
+                      options={{
+                        windowWidth: 1700,
+                      }}
+                    >
+                      <OssfChart
+                        repository={repoData.full_name}
+                        totalScore={repoData.ossf_scorecard_total_score}
+                        dependencyUpdateScore={repoData.ossf_scorecard_dependency_update_score}
+                        maintainedScore={repoData.ossf_scorecard_maintained_score}
+                        fuzzingScore={repoData.ossf_scorecard_fuzzing_score}
+                        isLoading={false}
+                        isError={!repoData.ossf_scorecard_total_score}
+                      />
+                    </CopyContainer>
                   </div>
 
                   <RossChart


### PR DESCRIPTION
## Description

This PR introduces a new component called `<CopyContainer />`. Anything you wrap with this component will be able to be copied as an image (in theory 😅). It's a wrapper component to copy the contents (children) as an image.

If you're curious about the options prop, it's the [same settings at the html2canvas configuration](https://html2canvas.hertzen.com/configuration).

## Related Tickets & Documents

Closes #3974
Relates to #3966

## Mobile & Desktop Screenshots/Recordings

![CleanShot 2024-08-16 at 15 52 29](https://github.com/user-attachments/assets/6351f79a-8601-4676-859d-251b1b2b24cf)

## Steps to QA

N/A (see the Storybook as it's not used in the codebase yet)

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/oCCLHVNt8YO64/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
