### PR TITLE
chore: Use DbUser for /contributor/search endpoint

### DIFF
--- a/components/molecules/ContributorListTableRow/contributor-list-table-row.stories.tsx
+++ b/components/molecules/ContributorListTableRow/contributor-list-table-row.stories.tsx
@@ -16,10 +16,9 @@ export const ContributorListTableRowStory = ContributorListTableRowTemplate.bind
 
 ContributorListTableRowStory.args = {
   contributor: {
-    author_login: "foxyblocks",
-    username: "foxyblocks",
+    login: "foxyblocks",
     updated_at: "2021-08-24T00:00:00.000Z",
-    user_id: 1,
+    id: 1,
     devstats_updated_at: "2021-08-24T00:00:00.000Z",
-  },
+  } as DbUserContributor,
 };

--- a/components/molecules/ContributorListTableRow/contributor-list-table-row.tsx
+++ b/components/molecules/ContributorListTableRow/contributor-list-table-row.tsx
@@ -20,10 +20,10 @@ import { getActivity } from "../RepoRow/repo-row";
 import DevProfile from "../DevProfile/dev-profile";
 
 interface ContributorListTableRow {
-  contributor: DbPRContributor;
+  contributor: DbUserContributor;
   topic: string;
   selected?: boolean;
-  handleOnSelectContributor?: (state: boolean, contributor: DbPRContributor) => void;
+  handleOnSelectContributor?: (state: boolean, contributor: DbUserContributor) => void;
   range: string;
   loggedIn: boolean;
   showOscr: boolean;
@@ -82,8 +82,8 @@ const ContributorListTableRow = ({
   showOscr,
 }: ContributorListTableRow) => {
   const [tableOpen, setTableOpen] = useState(false);
-  const login = contributor.author_login || contributor.username;
-  const { data: user } = useFetchUser(contributor.author_login);
+  const login = contributor.login;
+  const { data: user } = useFetchUser(contributor.login);
   const { data } = useContributorPullRequests({
     contributor: login,
     topic,
@@ -124,7 +124,7 @@ const ContributorListTableRow = ({
           <div className="w-[68%]">
             <DevProfile
               username={login}
-              hasBorder={!contributor.author_login}
+              hasBorder={!contributor.login}
               oscrRating={contributor.oscr}
               showOscr={showOscr}
               loggedIn={loggedIn}
@@ -207,7 +207,7 @@ const ContributorListTableRow = ({
         <div className={clsx("flex-1 lg:min-w-[12.5rem] overflow-hidden")}>
           <DevProfile
             username={login}
-            hasBorder={!contributor.author_login}
+            hasBorder={!contributor.login}
             showOscr={false}
             loggedIn={loggedIn}
             devstatsUpdatedAt={contributor.devstats_updated_at}
@@ -227,13 +227,13 @@ const ContributorListTableRow = ({
 
         {/* Column Repositories */}
         <div className={clsx("flex-1 hidden lg:flex lg:max-w-[6.25rem] justify-center")}>
-          {contributor.author_login ? repoList.length : "-"}
+          {contributor.login ? repoList.length : "-"}
         </div>
 
         {/* Column: Last Contribution */}
         <div className={clsx("flex-1 lg:max-w-[130px]  flex text-light-slate-11 justify-center ")}>
           <div className="flex flex-col">
-            <p>{contributor.author_login ? getLastContributionDate(mergedPrs) : "-"}</p>{" "}
+            <p>{contributor.login ? getLastContributionDate(mergedPrs) : "-"}</p>{" "}
             <p
               className="hidden whitespace-nowrap overflow-hidden overflow-ellipsis text-sm font-normal md:inline-flex text-light-slate-9 lg:max-w-[8.12rem]"
               title={user?.company || getLastContributedRepo(data)}
@@ -255,11 +255,11 @@ const ContributorListTableRow = ({
 
         {/* Column: Contributions */}
         <div className={clsx("flex-1 hidden justify-center  lg:flex lg:max-w-[7.5rem]")}>
-          <p>{contributor.author_login ? mergedPrs.length : "-"}</p>
+          <p>{contributor.login ? mergedPrs.length : "-"}</p>
         </div>
         {/* Column Last 30 Days */}
         <div className={clsx("flex-1 lg:min-w-[9.37rem] hidden lg:flex justify-center")}>
-          {contributor.author_login && last30days ? <Sparkline data={last30days} width="100%" height={54} /> : "-"}
+          {contributor.login && last30days ? <Sparkline data={last30days} width="100%" height={54} /> : "-"}
         </div>
       </div>
     </>

--- a/components/organisms/ContributorCard/contributor-card.stories.tsx
+++ b/components/organisms/ContributorCard/contributor-card.stories.tsx
@@ -1,13 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import ContributorCard from "./contributor-card";
 
-const baseContributor = Object.freeze({
-  author_login: "bdougie",
-  username: "bdougie",
+const baseContributor = {
+  login: "bdougie",
   updated_at: new Date("2020-01-01").toISOString(),
-  user_id: 5713670,
+  id: 5713670,
   devstats_updated_at: "2021-08-24T00:00:00.000Z",
-});
+} as DbUserContributor;
 
 const meta: Meta<typeof ContributorCard> = {
   title: "Design System/Organisms/Contributor Card",

--- a/components/organisms/ContributorCard/contributor-card.tsx
+++ b/components/organisms/ContributorCard/contributor-card.tsx
@@ -23,7 +23,7 @@ import { INITIAL_DEV_STATS_TIMESTAMP } from "lib/utils/devStats";
 
 interface ContributorCardProps {
   className?: string;
-  contributor: DbPRContributor | DbRepoContributor;
+  contributor: DbUserContributor | DbRepoContributor;
   topic: string;
   repositories?: number[];
   range?: string;
@@ -42,7 +42,7 @@ const ContributorCard = ({
   showOscr,
   excludeOscr = false,
 }: ContributorCardProps) => {
-  const username = "author_login" in contributor ? contributor.author_login : contributor.login;
+  const username = contributor.login;
   const [showPRs, setShowPRs] = useState(false);
   const githubAvatar = getAvatarByUsername(username);
   const { repoList, meta } = useContributorPullRequestsChart(username, topic, repositories, range);

--- a/components/organisms/ContributorProfilePage/contributor-profile-page.tsx
+++ b/components/organisms/ContributorProfilePage/contributor-profile-page.tsx
@@ -38,7 +38,7 @@ interface PrObjectType {
 }
 
 interface ContributorProfilePageProps {
-  contributor?: DbPRContributor;
+  contributor?: DbUserContributor;
   topic?: string;
   repositories?: number[];
   listOfPRs?: PrObjectType[];

--- a/components/organisms/Contributors/contributors.tsx
+++ b/components/organisms/Contributors/contributors.tsx
@@ -50,7 +50,7 @@ const Contributors = ({
   const { toast } = useToast();
   const { user, signIn } = useSupabaseAuth();
   const [layout, setLayout] = useState<ToggleValue>(defaultLayout);
-  const [selectedContributors, setSelectedContributors] = useState<DbPRContributor[]>([]);
+  const [selectedContributors, setSelectedContributors] = useState<DbUserContributor[]>([]);
   const [selectedListIds, setSelectedListIds] = useState<string[]>([]);
   const [popoverOpen, setPopoverOpen] = useState(false);
 
@@ -60,11 +60,11 @@ const Contributors = ({
     setLayout(isMobile ? "grid" : defaultLayout);
   }, [isMobile]);
 
-  const onSelectContributor = (state: boolean, contributor: DbPRContributor) => {
+  const onSelectContributor = (state: boolean, contributor: DbUserContributor) => {
     if (state) {
       setSelectedContributors((prev) => [...prev, contributor]);
     } else {
-      setSelectedContributors(selectedContributors.filter((selected) => selected.user_id !== contributor.user_id));
+      setSelectedContributors(selectedContributors.filter((selected) => selected.id !== contributor.id));
     }
   };
 
@@ -90,7 +90,7 @@ const Contributors = ({
         selectedListIds.map((listIds) =>
           addListContributor(
             listIds,
-            selectedContributors.map((contributor) => ({ id: contributor.user_id })),
+            selectedContributors.map((contributor) => ({ id: contributor.id })),
             workspaceId || personalWorkspaceId
           )
         )
@@ -155,9 +155,7 @@ const Contributors = ({
                 pathname: `/workspaces/${urlWorkspaceId}/contributor-insights/new`,
                 query: {
                   title: title ? `${title} Contributors` : "",
-                  contributors: JSON.stringify(
-                    selectedContributors.map((contributor) => contributor.author_login || contributor.username)
-                  ),
+                  contributors: JSON.stringify(selectedContributors.map((contributor) => contributor.login)),
                 },
               });
             }}

--- a/components/organisms/ContributorsList/contributors-list.tsx
+++ b/components/organisms/ContributorsList/contributors-list.tsx
@@ -9,7 +9,7 @@ import { ToggleValue } from "components/atoms/LayoutToggle/layout-toggle";
 import ContributorCard from "../ContributorCard/contributor-card";
 
 interface ContributorsListProps {
-  contributors: DbPRContributor[];
+  contributors: DbUserContributor[];
   isLoading: boolean;
   meta: Meta;
   setPage: (page: number) => void;
@@ -18,7 +18,7 @@ interface ContributorsListProps {
 }
 
 interface ContributorCardListProps {
-  contributors: DbPRContributor[];
+  contributors: DbUserContributor[];
   topic: string;
   range: string;
   loggedIn: boolean;
@@ -30,7 +30,7 @@ const ContributorCardList = ({ contributors = [], topic, range, loggedIn }: Cont
       {contributors.map((contributor) => {
         return (
           <ContributorCard
-            key={contributor.author_login}
+            key={contributor.login}
             contributor={contributor}
             topic={topic}
             range={range}

--- a/components/organisms/ContributorsTable/contributors-table.tsx
+++ b/components/organisms/ContributorsTable/contributors-table.tsx
@@ -3,11 +3,11 @@ import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
 import ContributorListTableRow from "components/molecules/ContributorListTableRow/contributor-list-table-row";
 
 export interface ContributorTableProps {
-  contributors: DbPRContributor[];
+  contributors: DbUserContributor[];
   topic: string;
   loading?: boolean;
-  selectedContributors?: DbPRContributor[];
-  handleSelectContributors?: (state: boolean, contributor: DbPRContributor) => void;
+  selectedContributors?: DbUserContributor[];
+  handleSelectContributors?: (state: boolean, contributor: DbUserContributor) => void;
   range?: string;
   noContributorsMessage?: string;
   loggedIn: boolean;
@@ -36,10 +36,8 @@ const ContributorTable = ({
               <ContributorListTableRow
                 topic={topic}
                 contributor={contributor}
-                key={contributor.user_id}
-                selected={
-                  !!selectedContributors?.find((selected) => selected.author_login === contributor.author_login)
-                }
+                key={contributor.id}
+                selected={!!selectedContributors?.find((selected) => selected.login === contributor.login)}
                 handleOnSelectContributor={handleSelectContributors}
                 range={range}
                 loggedIn={loggedIn}

--- a/components/organisms/Dashboard/dashboard.tsx
+++ b/components/organisms/Dashboard/dashboard.tsx
@@ -41,7 +41,7 @@ const Dashboard = ({ repositories, personalWorkspaceId }: DashboardProps): JSX.E
             "abbreviation"
           )}
           value={humanizeNumber(contributorMeta.itemCount, "comma")}
-          contributors={contributorData.map((contributor) => ({ host_login: contributor.author_login }))}
+          contributors={contributorData.map((contributor) => ({ host_login: contributor.login }))}
           isLoading={isLoading}
         />
         <HighlightCard

--- a/lib/hooks/api/useContributors.ts
+++ b/lib/hooks/api/useContributors.ts
@@ -6,7 +6,7 @@ import { publicApiFetcher } from "lib/utils/public-api-fetcher";
 import getFilterQuery from "lib/utils/get-filter-query";
 
 interface PaginatedResponse {
-  readonly data: DbPRContributor[];
+  readonly data: DbUserContributor[];
   readonly meta: Meta;
 }
 

--- a/next-types.d.ts
+++ b/next-types.d.ts
@@ -320,6 +320,7 @@ interface DbUserInsightRepo {
 }
 
 interface DbUser {
+  readonly avatar_url: string;
   readonly email: string;
   readonly id: number;
   readonly open_issues: number;
@@ -505,6 +506,16 @@ interface DBList {
 interface PagedData<T> {
   data?: T[];
   meta: Meta;
+}
+
+interface DbUserContributor extends DbUser {
+  commits: number;
+  prs_created: number;
+  issues_created: number;
+  issue_comments: number;
+  commit_comments: number;
+  pr_review_comments: number;
+  total_contributions: number;
 }
 
 interface DbRepoContributor {

--- a/pages/workspaces/[workspaceId]/contributors.tsx
+++ b/pages/workspaces/[workspaceId]/contributors.tsx
@@ -64,12 +64,11 @@ export default function WorkspaceContributorsPage({ workspace }: WorkspaceContri
   const contributors = data?.data
     ? Array.from(data.data, (info) => {
         return {
-          author_login: info.contributor.login,
-          username: info.contributor.username,
+          login: info.contributor.login,
           updated_at: info.contributor.updated_at,
-          user_id: info.contributor_id,
+          id: info.contributor_id,
           devstats_updated_at: info.contributor.devstats_updated_at,
-        };
+        } as DbUserContributor;
       })
     : [];
 


### PR DESCRIPTION
## Description

Followup to: https://github.com/open-sauced/api/pull/1039

> [!WARNING]
> Note: this should go in alongside the above API change. The API for `v2/contributor/search` will be returning `DbUser` (which includes the OSCR) now

## Related Tickets & Documents

Related to work in: https://github.com/open-sauced/app/issues/3859 - cc @zeucapua this is relevant to what you're working on with the OSCR in contributor search

## Mobile & Desktop Screenshots/Recordings

Things look good!

![Screenshot 2024-08-19 at 2 45 47 PM](https://github.com/user-attachments/assets/676e58aa-4cbb-4314-8a4c-0d04cd398189)

## Steps to QA

1. Run API locally (or wait for the API changes to land on beta)
2. Run App locally
3. Inspect workspaces table, contributor cards, and repo pages contributors still all work

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4