### PR TITLE
feat: now html2canvas-pro is dynamically imported only when needed and then cached

### DIFF
--- a/lib/utils/copy-to-clipboard.ts
+++ b/lib/utils/copy-to-clipboard.ts
@@ -1,5 +1,9 @@
-import html2canvas, { Options } from "html2canvas-pro";
+import { captureException } from "@sentry/nextjs";
+import type { Options } from "html2canvas-pro";
 import { shortenUrl } from "./shorten-url";
+
+type Html2CanvasSignature = (element: HTMLElement, options?: Partial<Options>) => Promise<HTMLCanvasElement>;
+let html2canvas: Html2CanvasSignature;
 
 export const copyToClipboard = async (content: string) => {
   try {
@@ -25,6 +29,7 @@ export async function copyImageToClipboard(imageUrl: string) {
     ]);
     return true;
   } catch (err) {
+    captureException(new Error("Failed to copy image to clipboard", { cause: err }));
     return false;
   }
 }
@@ -45,16 +50,25 @@ export async function copyNodeAsImage(node: HTMLElement | null, options?: Partia
   await navigator.clipboard.write([
     new ClipboardItem({
       "image/png": new Promise(async (resolve, reject) => {
-        html2canvas(node, options).then((canvas) => {
-          canvas.toBlob((blob) => {
-            if (!blob) {
-              reject("Failed to copy image to clipboard");
-              return;
-            }
+        try {
+          if (!html2canvas) {
+            html2canvas = (await import("html2canvas-pro")).default;
+          }
 
-            resolve(new Blob([blob], { type: "image/png" }));
-          }, "image/png");
-        });
+          html2canvas(node, options).then((canvas) => {
+            canvas.toBlob((blob) => {
+              if (!blob) {
+                reject("Failed to copy image to clipboard");
+                return;
+              }
+
+              resolve(new Blob([blob], { type: "image/png" }));
+            }, "image/png");
+          });
+        } catch (err) {
+          reject("Failed to copy image to clipboard");
+          captureException(new Error("Failed to copy image to clipboard", { cause: err }));
+        }
       }),
     }),
   ]);


### PR DESCRIPTION
## Description

Now html2canvas-pro is dynamically imported only when needed and then cached, saving about a 45kb of JS loading on any page that uses it on initial page load.

## Related Tickets & Documents

Closes #4033

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. Go to a repository page, e.g. https://deploy-preview-3966--oss-insights.netlify.app/s/kubernetes/kubernetes
2. Hover over the Contributor Confidence card.
3. Notice the copy button appears in the top right corner.
4. Click it.
5. A toast message says the image was copied.
6. Paste the image in for example GitHub markdown, socials, Slack etc.
7. The image of the given stat/graph appears.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/xT9IgqYHYClWb2eZnG/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
