### PR TITLE
fix: now search dialog is always on top of other elements

### DIFF
--- a/components/organisms/SearchDialog/search-dialog.tsx
+++ b/components/organisms/SearchDialog/search-dialog.tsx
@@ -15,6 +15,7 @@ import useDebounceTerm from "lib/hooks/useDebounceTerm";
 import useIsMacOS from "lib/hooks/useIsMacOS";
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
 import { useSearchRepos } from "lib/hooks/useSearchRepos";
+import { Dialog, DialogContent, DialogTrigger } from "components/molecules/Dialog/dialog";
 
 const SearchDialog = () => {
   useLockBody();
@@ -26,6 +27,7 @@ const SearchDialog = () => {
   const [isSearching, setIsSearching] = useState(false);
   const [isSearchError, setIsSearchError] = useState(false);
   const setOpenSearch = store((state) => state.setOpenSearch);
+  const openSearch = store((state) => state.openSearch);
   const debouncedSearchTerm = useDebounceTerm(searchTerm, 300);
   const {
     data: repoData,
@@ -136,50 +138,68 @@ const SearchDialog = () => {
   };
 
   return (
-    <div className="fixed left-0 top-0 z-auto p-5 w-full h-full flex justify-center bg-white/30">
-      <div className="absolute w-full h-full left-0 top-0 z-50 backdrop-blur-sm" onClick={() => setOpenSearch(false)} />
-      <div
-        className="flex flex-col w-full max-w-2xl h-fit max-h-full bg-white shadow-xl border transition rounded-lg ring-light-slate-6 relative z-50 overflow-hidden"
-        onMouseMove={() => cursor !== -1 && setCursor(-1)}
-      >
-        <div className="flex w-full h-full items-center border-b p-2 pl-3">
-          {isSearching ? (
-            <div className="flex-none w-4 h-4 rounded-full border-2 border-light-slate-9 border-b-light-slate-5 border-r-light-slate-5 animate-spin" />
-          ) : (
+    <Dialog open={openSearch} onOpenChange={setOpenSearch}>
+      <DialogTrigger asChild>
+        <button className="hidden sm:flex justify-between p-1 pl-3 h-fit w-56 sm:w-64 ml-auto bg-white border rounded-lg ring-light-slate-6 relative overflow-hidden">
+          <div className="flex items-center">
             <FaSearch className="text-light-slate-9" fontSize={16} />
-          )}
-          <input
-            autoFocus
-            className="w-full pl-2 text-sm font-semibold text-slate-700 focus:outline-none"
-            value={searchTerm}
-            onChange={(e) => {
-              setSearchTerm(e.target.value);
-              isSearchError && setIsSearchError(false);
-            }}
-            onKeyDown={handleKeyboardCtrl}
-          />
-          <Text keyboard className="text-gray-600 !border-b !px-1">
-            {isMac ? "⌘K" : <span className="text-xs py-2 px-1">CTRL+K</span>}
+            <Text className="pl-2 text-sm text-light-slate-9">Users, Repositories...</Text>
+          </div>
+          <Text className="text-gray-600 !border-b !px-1">
+            {isMac ? "⌘K" : <span className="text-xs px-1 py-2">CTRL+K</span>}
           </Text>
+        </button>
+      </DialogTrigger>
+      <DialogContent>
+        <div className="fixed left-0 top-0 z-auto p-5 w-full h-full flex justify-center bg-white/30">
+          <div
+            className="absolute w-full h-full left-0 top-0 z-50 backdrop-blur-sm"
+            onClick={() => setOpenSearch(false)}
+          />
+          <div
+            className="flex flex-col w-full max-w-2xl h-fit max-h-full bg-white shadow-xl border transition rounded-lg ring-light-slate-6 relative z-50 overflow-hidden"
+            onMouseMove={() => cursor !== -1 && setCursor(-1)}
+          >
+            <div className="flex w-full h-full items-center border-b p-2 pl-3">
+              {isSearching ? (
+                <div className="flex-none w-4 h-4 rounded-full border-2 border-light-slate-9 border-b-light-slate-5 border-r-light-slate-5 animate-spin" />
+              ) : (
+                <FaSearch className="text-light-slate-9" fontSize={16} />
+              )}
+              <input
+                autoFocus
+                className="w-full pl-2 text-sm font-semibold text-slate-700 focus:outline-none"
+                value={searchTerm}
+                onChange={(e) => {
+                  setSearchTerm(e.target.value);
+                  isSearchError && setIsSearchError(false);
+                }}
+                onKeyDown={handleKeyboardCtrl}
+              />
+              <Text keyboard className="text-gray-600 !border-b !px-1">
+                {isMac ? "⌘K" : <span className="text-xs py-2 px-1">CTRL+K</span>}
+              </Text>
+            </div>
+            <div className="w-full h-full flex flex-col items-center">
+              {searchTerm.length < 3 ? (
+                <SearchInfo />
+              ) : isSearchError && !isSearching && (repoDataError || repoData.length === 0) ? (
+                <Text className="block w-full py-1 px-4 text-sauced-orange !font-normal leading-6">
+                  <HiOutlineExclamation className="text-sauced-orange inline-flex mr-2.5" fontSize={20} />
+                  We couldn&apos;t find any users or repositories with that name
+                </Text>
+              ) : (
+                <>
+                  <section className="flex flex-col w-full">{renderUserSearchState()}</section>
+                  <hr />
+                  <section className="flex flex-col w-full">{renderRepoSearchState()}</section>
+                </>
+              )}
+            </div>
+          </div>
         </div>
-        <div className="w-full h-full flex flex-col items-center">
-          {searchTerm.length < 3 ? (
-            <SearchInfo />
-          ) : isSearchError && !isSearching && (repoDataError || repoData.length === 0) ? (
-            <Text className="block w-full py-1 px-4 text-sauced-orange !font-normal leading-6">
-              <HiOutlineExclamation className="text-sauced-orange inline-flex mr-2.5" fontSize={20} />
-              We couldn&apos;t find any users or repositories with that name
-            </Text>
-          ) : (
-            <>
-              <section className="flex flex-col w-full">{renderUserSearchState()}</section>
-              <hr />
-              <section className="flex flex-col w-full">{renderRepoSearchState()}</section>
-            </>
-          )}
-        </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/components/organisms/SearchDialog/search-dialog.tsx
+++ b/components/organisms/SearchDialog/search-dialog.tsx
@@ -140,14 +140,13 @@ const SearchDialog = () => {
   return (
     <Dialog open={openSearch} onOpenChange={setOpenSearch}>
       <DialogContent
-        className="fixed top-0 p-5 flex justify-center"
+        className="fixed top-2 lg:top-4 flex justify-center !pb-0 lg:!p-0 bg-transparent !w-full"
         onPointerDownOutside={() => {
-          alert("clicked outside");
           setOpenSearch(false);
         }}
       >
         <div
-          className="flex flex-col w-full max-w-2xl h-fit max-h-full bg-white shadow-xl border transition rounded-lg ring-light-slate-6 relative z-50 overflow-hidden"
+          className="mx-1 md:mx-2 flex flex-col w-full max-w-2xl h-fit max-h-full bg-white shadow-xl border transition rounded-lg ring-light-slate-6 relative z-50 overflow-hidden"
           onMouseMove={() => cursor !== -1 && setCursor(-1)}
         >
           <div className="flex w-full h-full items-center border-b p-2 pl-3">

--- a/components/organisms/SearchDialog/search-dialog.tsx
+++ b/components/organisms/SearchDialog/search-dialog.tsx
@@ -15,7 +15,7 @@ import useDebounceTerm from "lib/hooks/useDebounceTerm";
 import useIsMacOS from "lib/hooks/useIsMacOS";
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
 import { useSearchRepos } from "lib/hooks/useSearchRepos";
-import { Dialog, DialogContent, DialogTrigger } from "components/molecules/Dialog/dialog";
+import { Dialog, DialogContent } from "components/molecules/Dialog/dialog";
 
 const SearchDialog = () => {
   useLockBody();
@@ -139,63 +139,52 @@ const SearchDialog = () => {
 
   return (
     <Dialog open={openSearch} onOpenChange={setOpenSearch}>
-      <DialogTrigger asChild>
-        <button className="hidden sm:flex justify-between p-1 pl-3 h-fit w-56 sm:w-64 ml-auto bg-white border rounded-lg ring-light-slate-6 relative overflow-hidden">
-          <div className="flex items-center">
-            <FaSearch className="text-light-slate-9" fontSize={16} />
-            <Text className="pl-2 text-sm text-light-slate-9">Users, Repositories...</Text>
+      <DialogContent
+        className="fixed top-0 p-5 flex justify-center"
+        onPointerDownOutside={() => {
+          alert("clicked outside");
+          setOpenSearch(false);
+        }}
+      >
+        <div
+          className="flex flex-col w-full max-w-2xl h-fit max-h-full bg-white shadow-xl border transition rounded-lg ring-light-slate-6 relative z-50 overflow-hidden"
+          onMouseMove={() => cursor !== -1 && setCursor(-1)}
+        >
+          <div className="flex w-full h-full items-center border-b p-2 pl-3">
+            {isSearching ? (
+              <div className="flex-none w-4 h-4 rounded-full border-2 border-light-slate-9 border-b-light-slate-5 border-r-light-slate-5 animate-spin" />
+            ) : (
+              <FaSearch className="text-light-slate-9" fontSize={16} />
+            )}
+            <input
+              autoFocus
+              className="w-full pl-2 text-sm font-semibold text-slate-700 focus:outline-none"
+              value={searchTerm}
+              onChange={(e) => {
+                setSearchTerm(e.target.value);
+                isSearchError && setIsSearchError(false);
+              }}
+              onKeyDown={handleKeyboardCtrl}
+            />
+            <Text keyboard className="text-gray-600 !border-b !px-1">
+              {isMac ? "⌘K" : <span className="text-xs py-2 px-1">CTRL+K</span>}
+            </Text>
           </div>
-          <Text className="text-gray-600 !border-b !px-1">
-            {isMac ? "⌘K" : <span className="text-xs px-1 py-2">CTRL+K</span>}
-          </Text>
-        </button>
-      </DialogTrigger>
-      <DialogContent>
-        <div className="fixed left-0 top-0 z-auto p-5 w-full h-full flex justify-center bg-white/30">
-          <div
-            className="absolute w-full h-full left-0 top-0 z-50 backdrop-blur-sm"
-            onClick={() => setOpenSearch(false)}
-          />
-          <div
-            className="flex flex-col w-full max-w-2xl h-fit max-h-full bg-white shadow-xl border transition rounded-lg ring-light-slate-6 relative z-50 overflow-hidden"
-            onMouseMove={() => cursor !== -1 && setCursor(-1)}
-          >
-            <div className="flex w-full h-full items-center border-b p-2 pl-3">
-              {isSearching ? (
-                <div className="flex-none w-4 h-4 rounded-full border-2 border-light-slate-9 border-b-light-slate-5 border-r-light-slate-5 animate-spin" />
-              ) : (
-                <FaSearch className="text-light-slate-9" fontSize={16} />
-              )}
-              <input
-                autoFocus
-                className="w-full pl-2 text-sm font-semibold text-slate-700 focus:outline-none"
-                value={searchTerm}
-                onChange={(e) => {
-                  setSearchTerm(e.target.value);
-                  isSearchError && setIsSearchError(false);
-                }}
-                onKeyDown={handleKeyboardCtrl}
-              />
-              <Text keyboard className="text-gray-600 !border-b !px-1">
-                {isMac ? "⌘K" : <span className="text-xs py-2 px-1">CTRL+K</span>}
+          <div className="w-full h-full flex flex-col items-center">
+            {searchTerm.length < 3 ? (
+              <SearchInfo />
+            ) : isSearchError && !isSearching && (repoDataError || repoData.length === 0) ? (
+              <Text className="block w-full py-1 px-4 text-sauced-orange !font-normal leading-6">
+                <HiOutlineExclamation className="text-sauced-orange inline-flex mr-2.5" fontSize={20} />
+                We couldn&apos;t find any users or repositories with that name
               </Text>
-            </div>
-            <div className="w-full h-full flex flex-col items-center">
-              {searchTerm.length < 3 ? (
-                <SearchInfo />
-              ) : isSearchError && !isSearching && (repoDataError || repoData.length === 0) ? (
-                <Text className="block w-full py-1 px-4 text-sauced-orange !font-normal leading-6">
-                  <HiOutlineExclamation className="text-sauced-orange inline-flex mr-2.5" fontSize={20} />
-                  We couldn&apos;t find any users or repositories with that name
-                </Text>
-              ) : (
-                <>
-                  <section className="flex flex-col w-full">{renderUserSearchState()}</section>
-                  <hr />
-                  <section className="flex flex-col w-full">{renderRepoSearchState()}</section>
-                </>
-              )}
-            </div>
+            ) : (
+              <>
+                <section className="flex flex-col w-full">{renderUserSearchState()}</section>
+                <hr />
+                <section className="flex flex-col w-full">{renderRepoSearchState()}</section>
+              </>
+            )}
           </div>
         </div>
       </DialogContent>

--- a/components/organisms/SearchDialog/search-dialog.tsx
+++ b/components/organisms/SearchDialog/search-dialog.tsx
@@ -257,13 +257,6 @@ const SearchLoading = () => (
   </div>
 );
 
-const SearchError = () => (
-  <Text className="block w-full py-1 px-4 text-sauced-orange !font-normal leading-6">
-    <HiOutlineExclamation className="text-sauced-orange inline-flex mr-2.5" fontSize={20} />
-    We couldn&apos;t find any users or repositories with that name
-  </Text>
-);
-
 const SearchResult = ({ result, cursor }: { result: GhUser[]; cursor: number }) => (
   <div className="w-full py-1 overflow-hidden text-gray-600">
     <Text className="block w-full py-1 px-4">Users</Text>


### PR DESCRIPTION
## Description

Now search dialog is always on top of other elements. I'm just going to adjust the overlay to the color it was originally (more white).

## Related Tickets & Documents

Fixes #3614

## Mobile & Desktop Screenshots/Recordings

**Before**

![CleanShot 2024-08-27 at 15 16 22](https://github.com/user-attachments/assets/928805e4-c9bd-4a44-b603-c01b964393e7)

**After**

![CleanShot 2024-08-27 at 16 11 46](https://github.com/user-attachments/assets/df0343bf-2157-4330-881e-6b21642cda45)

## Steps to QA

1. Go to a repository page, e.g. /s/kubernetes/kubernetes
2. Open the search dialog. Notice the logo as well as other graphs no longer bleed through the search bar or the overlay.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/2WdGnOk4slkyIo6DUW/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
