### PR TITLE
feat: Use self hosted GitHub actions runners

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -16,7 +16,7 @@ jobs:
 
   build:
     name: Build application
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: "☁️ checkout repository"

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -2,6 +2,7 @@
 # https://github.com/marketplace/actions/create-or-update-comment (https://github.com/peter-evans/create-or-update-comment)
 
 name: Automatic Comment
+
 on:
   issues:
     types: [opened]
@@ -14,7 +15,7 @@ jobs:
       issues: write  # for peter-evans/create-or-update-comment to create or update comment
       pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     name: Comment
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Automatic Comment
         uses: peter-evans/create-or-update-comment@v2

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,5 @@
 name: Playwright Tests
+
 on:
   push:
     branches: [main, beta]
@@ -11,7 +12,7 @@ jobs:
   test:
     name: E2E Tests
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   setup:
     name: Set environment variables
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     outputs:
       DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.DEPLOY_ENVIRONMENT }}
@@ -28,7 +28,7 @@ jobs:
 
   build:
     name: Build application
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: "☁️ checkout repository"
@@ -63,7 +63,7 @@ jobs:
       - setup
       - test
       - build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: Generate token
@@ -96,7 +96,7 @@ jobs:
     name: Cleanup actions
     needs:
       - release
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: "♻️ remove build artifacts"

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: "☁️ checkout repository"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,5 +1,4 @@
 name: "Assign issues with .take"
-
 on:
   issue_comment:
     types:
@@ -9,7 +8,7 @@ on:
 jobs:
   take-issue:
     name: Disable take issue
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: take an issue


### PR DESCRIPTION
## Description

Uses GitHub action self hosted runners. These are _slightly_ more powerful runners that should hopefully make it so actions are less painful and the e2e tests don't flake as much.

## Related Tickets & Documents

Related to: #3946 

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4