### PR TITLE
fix(ossfchart.tsx): remove z-index and move "I want this now!" button JSX below ResponsiveContainer

### DIFF
--- a/components/Repositories/OssfChart.tsx
+++ b/components/Repositories/OssfChart.tsx
@@ -121,13 +121,6 @@ export default function OssfChart({
         ) : (
           <section className="flex justify-between items-center w-full gap-2 lg:flex-col xl:flex-row h-fit max-h-24 lg:max-h-full xl:max-h-24">
             <div className="relative w-full !max-w-[14rem] lg:max-w-full lg:mx-auto h-full lg:max-h-24 xl:h-full">
-              {isError && (
-                <div className="absolute inset-0 z-50 flex items-center justify-center">
-                  <Button variant="primary" onClick={onRequestClick} className="!text-xs">
-                    I want this now!
-                  </Button>
-                </div>
-              )}
               <ResponsiveContainer width="100%" height={150} className={`${isError && "blur-[2.5px]"}`}>
                 <PieChart>
                   <Pie
@@ -146,6 +139,13 @@ export default function OssfChart({
                   </Pie>
                 </PieChart>
               </ResponsiveContainer>
+              {isError && (
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <Button variant="primary" onClick={onRequestClick} className="!text-xs">
+                    I want this now!
+                  </Button>
+                </div>
+              )}
             </div>
             <section className="flex flex-col gap-1 lg:text-center xl:text-start">
               <h3 className="font-medium text-sm text-slate-700">{projectStatus}</h3>


### PR DESCRIPTION
fix #4055 

## Description

This PR fixes Bug #4055: Removed the z-index from the OssfChart component's "I want this now!" button JSX and moved the JSX below the ResponsiveContainer component. This achieves the desired effect of the component without any odd z-index behavior.

## Related Tickets & Documents
Fixes #4055 

## Mobile & Desktop Screenshots/Recordings

N/A


## Steps to QA
No tests written. Look at code on lines 142 - 148 of [OssfChart.tsx](https://github.com/ryandotfurrer/open-sauced_app/blob/bug-fix_remove-unnecessary-z-index-openssf-score-card/components/Repositories/OssfChart.tsx) to see the changed code.

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?
![Pizza I Love GIF](https://github.com/user-attachments/assets/7418cb64-905c-4b67-b72f-ce871c09638d)

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
