### PR TITLE
fix: Use correct github action yamls

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -16,6 +16,7 @@ jobs:
 
   build:
     name: Build application
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: "☁️ checkout repository"
@@ -25,6 +26,7 @@ jobs:
         uses: actions/setup-node@v2.1.5
         with:
           node-version: 18
+          cache: "npm"
 
       - name: "🔧 install npm@latest"
         run: npm i -g npm@latest

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -15,6 +15,7 @@ jobs:
       issues: write  # for peter-evans/create-or-update-comment to create or update comment
       pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
     name: Comment
+    runs-on: ubuntu-latest
     steps:
       - name: Automatic Comment
         uses: peter-evans/create-or-update-comment@v2

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          cache: "npm"
       - name: Install dependencies
         run: npm ci
       - name: Build App

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   setup:
     name: Set environment variables
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
       DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.DEPLOY_ENVIRONMENT }}
@@ -27,6 +28,7 @@ jobs:
 
   build:
     name: Build application
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: "☁️ checkout repository"
@@ -36,6 +38,7 @@ jobs:
         uses: actions/setup-node@v2.1.5
         with:
           node-version: 18
+          cache: "npm"
 
       - name: "🔧 install npm@latest"
         run: npm i -g npm@latest
@@ -61,6 +64,7 @@ jobs:
       - setup
       - test
       - build
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Generate token
@@ -93,6 +97,7 @@ jobs:
     name: Cleanup actions
     needs:
       - release
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: "♻️ remove build artifacts"

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   deploy:
     timeout-minutes: 10
+    runs-on: ubuntu-latest
     steps:
       - name: "☁️ checkout repository"
         uses: actions/checkout@v2
@@ -21,6 +22,7 @@ jobs:
         uses: actions/setup-node@v2.1.5
         with:
           node-version: 18
+          cache: "npm"
 
       - name: "🔧 install npm@latest"
         run: npm i -g npm@latest

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   take-issue:
     name: Disable take issue
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: take an issue


### PR DESCRIPTION
## Description

- Uses the correct `runs-on` key / value in each action
- Uses the NPM setup action cache for caching dependencies: https://github.com/actions/setup-node?tab=readme-ov-file#caching-global-packages-data

## Related Tickets & Documents

Fast follow to: #4069 

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4