### PR TITLE
feat: Improve Repo Listing and Filtering in Contributor Area Graph

### DIFF
--- a/components/molecules/CardRepoList/RemainingReposTooltip.tsx
+++ b/components/molecules/CardRepoList/RemainingReposTooltip.tsx
@@ -1,0 +1,23 @@
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { ReactNode } from "react";
+
+interface RemainingReposTooltipProps {
+  content: ReactNode;
+  trigger: ReactNode;
+}
+
+const RemainingReposTooltip = ({ content, trigger }: RemainingReposTooltipProps) => {
+  return (
+    <Tooltip.Provider>
+      <Tooltip.Root>
+        <Tooltip.Trigger>{trigger}</Tooltip.Trigger>
+        <Tooltip.Content className="bg-white text-gray-900 p-2 rounded-md shadow-lg max-w-xs border border-gray-200">
+          {content}
+          <Tooltip.Arrow className="fill-white" />
+        </Tooltip.Content>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+};
+
+export default RemainingReposTooltip;

--- a/components/molecules/CardRepoList/card-repo-list.tsx
+++ b/components/molecules/CardRepoList/card-repo-list.tsx
@@ -1,8 +1,9 @@
 import { StaticImageData } from "next/image";
 import { ImCross } from "react-icons/im";
 import { useState } from "react";
+import Tooltip_Custom from "components/atoms/Tooltip/tooltip";
 import Icon from "components/atoms/Icon/icon";
-import Tooltip from "components/atoms/Tooltip/tooltip";
+import RemainingReposTooltip from "./RemainingReposTooltip";
 
 export interface RepoList {
   repoOwner: string;
@@ -31,10 +32,18 @@ const CardRepoList = ({
   onSelect = () => {},
   showCursor = false,
 }: CardRepoListProps): JSX.Element => {
-  // The repoList is paginated, the total is the complete count
   const repoTotal = total || repoList.length;
   const sanitizedRepoList = [...new Map(repoList.map((item) => [item["repoName"], item])).values()];
   const [selectedRepo, setSelectedRepo] = useState<string>("");
+
+  const remainingRepos = sanitizedRepoList
+    .filter((_, arrCount) => arrCount >= limit)
+    .map(({ repoOwner, repoName, repoIcon }) => (
+      <div key={repoName} className="flex items-center gap-2 py-1">
+        <Icon IconImage={repoIcon} className="rounded-[4px] overflow-hidden" />
+        <span className="text-sm">{`${repoOwner}/${repoName}`}</span>
+      </div>
+    ));
 
   return (
     <div className="flex gap-1 items-center max-w[175px] truncate flex-wrap text-xs text-light-slate-9">
@@ -42,57 +51,62 @@ const CardRepoList = ({
         <>
           {sanitizedRepoList
             .filter((_, arrCount) => arrCount < limit)
-            .map(({ repoOwner, repoName, repoIcon }, index) => {
-              return (
-                <div
-                  key={`repo_${index}`}
-                  onClick={() => {
-                    if (!selectedRepo) {
-                      onSelect(`${repoOwner}/${repoName}`);
-                      setSelectedRepo(`${repoOwner}/${repoName}`);
-                    } else {
-                      onSelect("");
-                      setSelectedRepo("");
-                    }
-                  }}
-                >
-                  {repoName && repoIcon ? (
-                    <Tooltip content={`${repoOwner}/${repoName}`}>
-                      <div
-                        className={`flex gap-1  p-1 pr-2 border-[1px] border-light-slate-6 rounded-lg text-light-slate-12 ${
-                          selectedRepo === `${repoOwner}/${repoName}` && "border-orange-500"
+            .map(({ repoOwner, repoName, repoIcon }, index) => (
+              <div
+                key={`repo_${index}`}
+                onClick={() => {
+                  if (!selectedRepo) {
+                    onSelect(`${repoOwner}/${repoName}`);
+                    setSelectedRepo(`${repoOwner}/${repoName}`);
+                  } else {
+                    onSelect("");
+                    setSelectedRepo("");
+                  }
+                }}
+              >
+                {repoName && repoIcon ? (
+                  <Tooltip_Custom content={`${repoOwner}/${repoName}`}>
+                    <div
+                      className={`flex gap-1 p-1 pr-2 border-[1px] border-light-slate-6 rounded-lg text-light-slate-12 ${
+                        selectedRepo === `${repoOwner}/${repoName}` && "border-orange-500"
+                      }`}
+                    >
+                      <Icon IconImage={repoIcon} className="rounded-[4px] overflow-hidden" />
+                      <span
+                        className={`max-w-[45px] md:max-w-[100px] truncate ${fontSizeClassName} ${
+                          showCursor && "cursor-pointer"
                         }`}
                       >
-                        <Icon IconImage={repoIcon} className="rounded-[4px] overflow-hidden" />
-                        <span
-                          className={`max-w-[45px] md:max-w-[100px] truncate ${fontSizeClassName} ${
-                            showCursor && "cursor-pointer"
-                          }`}
+                        {repoName}
+                      </span>
+                      {deletable ? (
+                        <button
+                          className="flex items-center justify-center w-4 h-4 rounded-full bg-light-slate-6 hover:bg-light-slate-5 transition-colors duration-300 p-1"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            onDelete(repoName);
+                          }}
                         >
-                          {repoName}
-                        </span>
-                        {deletable ? (
-                          <button
-                            className="flex items-center justify-center w-4 h-4 rounded-full bg-light-slate-6 hover:bg-light-slate-5 transition-colors duration-300 p-1"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              onDelete(repoName);
-                            }}
-                          >
-                            <ImCross className="w-3 h-3 text-light-slate-12" />
-                          </button>
-                        ) : (
-                          ""
-                        )}
-                      </div>
-                    </Tooltip>
-                  ) : (
-                    ""
-                  )}
-                </div>
-              );
-            })}
-          <div>{repoTotal > limit ? `+${repoTotal - limit}` : null}</div>
+                          <ImCross className="w-3 h-3 text-light-slate-12" />
+                        </button>
+                      ) : (
+                        ""
+                      )}
+                    </div>
+                  </Tooltip_Custom>
+                ) : (
+                  ""
+                )}
+              </div>
+            ))}
+          <RemainingReposTooltip
+            trigger={<div>{repoTotal > limit ? `+${repoTotal - limit}` : null}</div>}
+            content={
+              <div className="flex flex-col">
+                {remainingRepos.length > 0 ? remainingRepos : <span>No additional repositories</span>}
+              </div>
+            }
+          />
         </>
       ) : (
         <p className="mr-2 font-normal text-slate-400 text-sm">No repositories tagged...</p>


### PR DESCRIPTION
## Description

This PR adds a new tooltip component for displaying additional repository information in the CardRepoList component. The new RemainingReposTooltip component provides a consistent and improved way to show additional repository details when the number of repositories exceeds the specified limit. This update enhances user experience by providing better visual feedback and organization.

edit: Background can be made to dark after review i kept it light to maintain the composition.

fixes #4005 

## Related Tickets & Documents

fixes #4005 


## Mobile & Desktop Screenshots/Recordings

[screen-capture (40).webm](https://github.com/user-attachments/assets/d2f9e6f4-c048-48e1-afeb-faad3292af16)

<!-- Visual changes require screenshots -->


## Steps to QA

1. Select the profile of any contributor
2. Change range to 1 year
3. if the contributed repos will be more than 7 , hover over the remaining repos.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [ ] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
