### PR TITLE
chore: now hidden files are included in production artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           name: build
           path: .next
+          include-hidden-files: true
 
   release:
     environment:


### PR DESCRIPTION
## Description

Now hidden files are included in production artifacts because the build output of Next.js is the `.next` folder. This wasn't an issue prior to `actions/upload-artifact@v4`.

## Related Tickets & Documents

Closes #4096

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

N/A


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media3.giphy.com/media/H1zIfgQFWJR82Et8Uw/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
