### PR TITLE
fix: redirect all explore requests to the new explore page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -125,7 +125,28 @@ module.exports = millionLint({
       ...interests.map((interest) => {
         return {
           source: `/${interest}/:tool(dashboard|reports|contributors|activity)`,
-          destination: `/explore/topic/${interest}/:tool`,
+          destination: `/explore`,
+          permanent: true,
+        };
+      }),
+      ...interests.map((interest) => {
+        return {
+          source: `/explore/topic/${interest}/:tool(dashboard|reports|contributors|activity)`,
+          destination: `/explore`,
+          permanent: true,
+        };
+      }),
+      ...interests.map((interest) => {
+        return {
+          source: `/explore/topic/${interest}`,
+          destination: `/explore`,
+          permanent: true,
+        };
+      }),
+      ...interests.map((interest) => {
+        return {
+          source: `/${interest}`,
+          destination: `/explore`,
           permanent: true,
         };
       }),
@@ -138,14 +159,6 @@ module.exports = millionLint({
         source: "/user/:user((?!settings|notifications$).*)",
         destination: "/u/:user",
         permanent: true,
-      },
-    ];
-  },
-  async rewrites() {
-    return [
-      {
-        source: "/explore/topic/:topic",
-        destination: "/explore/topic/:topic/dashboard/filter/recent",
       },
     ];
   },

--- a/next.config.js
+++ b/next.config.js
@@ -129,20 +129,11 @@ module.exports = millionLint({
           permanent: true,
         };
       }),
-      ...interests.map((interest) => {
-        return {
-          source: `/explore/topic/${interest}/:tool(dashboard|reports|contributors|activity)`,
-          destination: `/explore`,
-          permanent: true,
-        };
-      }),
-      ...interests.map((interest) => {
-        return {
-          source: `/explore/topic/${interest}`,
-          destination: `/explore`,
-          permanent: true,
-        };
-      }),
+      {
+        source: `/explore/topic/:slug*`,
+        destination: `/explore`,
+        permanent: true,
+      },
       ...interests.map((interest) => {
         return {
           source: `/${interest}`,


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
- Adds redirects to the new explore page from the topic-based pages

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Closes #4111 

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
1. Go to /explore/topic/typescript
2. Go to /typescript
3. Go to /typescript/dashboard
4. Note all should redirect to `/explore`

## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/s7LrWWLeWLumc/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
