### PR TITLE
chore: now hot.opensauced.pizza/* redirects to app.opensauced.pizza/explore

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -16,25 +16,31 @@ targetPort = 3001
 deno_import_map = "./netlify/edge-functions/deno.json"
 
 [[redirects]]
-  from = "https://insight.opensauced.pizza/*"
-  to = "https://insights.opensauced.pizza/:splat"
-  status = 301
-  force = true
+from = "https://insight.opensauced.pizza/*"
+to = "https://insights.opensauced.pizza/:splat"
+status = 301
+force = true
 
 [[redirects]]
-  from = "https://insights.opensauced.pizza/*"
-  to = "https://app.opensauced.pizza/:splat"
-  status = 301
-  force = true
+from = "https://insights.opensauced.pizza/*"
+to = "https://app.opensauced.pizza/:splat"
+status = 301
+force = true
 
 [[redirects]]
-  from = "https://beta.insights.opensauced.pizza/*"
-  to = "https://beta.app.opensauced.pizza/:splat"
-  status = 301
-  force = true
+from = "https://beta.insights.opensauced.pizza/*"
+to = "https://beta.app.opensauced.pizza/:splat"
+status = 301
+force = true
 
 [[redirects]]
-  from = "https://oscr.me/:username"
-  to = "https://app.opensauced.pizza/u/:username/card"
-  status = 301
-  force = true
+from = "https://oscr.me/:username"
+to = "https://app.opensauced.pizza/u/:username/card"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://hot.opensauced.pizza/*"
+to = "https://app.opensauced.pizza/explore"
+status = 301
+force = true


### PR DESCRIPTION
## Description

Now hot.opensauced.pizza/* links redirects to app.opensauced.pizza/explore. Once this is deployed to production, we can change whhich app hot.opensauced.pizza points to in the Netlify dashboard.

## Related Tickets & Documents

Closes #4142

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA

1. This can't be tested until the redirect in this PR is in production.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
