### PR TITLE
fix: a11y rule "no-noninteractive-element-interactions"

### DIFF
--- a/components/atoms/Fab/fab.tsx
+++ b/components/atoms/Fab/fab.tsx
@@ -5,7 +5,7 @@ interface FabProps extends React.HTMLAttributes<HTMLButtonElement> {
   position?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
   onClick?: () => void;
 }
-const Fab = ({ position, children, className }: FabProps) => {
+const Fab = ({ position, children, className, onClick }: FabProps) => {
   const getFabPositionStyles = () => {
     switch (position) {
       case "top-left":
@@ -21,7 +21,7 @@ const Fab = ({ position, children, className }: FabProps) => {
     }
   };
   return (
-    <button type="button" className={clsx("fixed", getFabPositionStyles(), className)}>
+    <button type="button" onClick={onClick} className={clsx("fixed", getFabPositionStyles(), className)}>
       {children}
     </button>
   );

--- a/components/molecules/HighlightInput/highlight-input-form.tsx
+++ b/components/molecules/HighlightInput/highlight-input-form.tsx
@@ -754,14 +754,14 @@ const HighlightInputForm = ({ refreshCallback }: HighlightInputFormProps): JSX.E
                                   }`}
                                 />
                               )}
-                              <p
-                                className="text-light-slate-11 truncate max-w-[14rem] xs:max-w-[16rem] text-xs xs:text-sm cursor-pointer hover:text-orange-600 transition"
+                              <button
+                                className="outline-none bg-none text-light-slate-11 truncate max-w-[14rem] xs:max-w-[16rem] text-xs xs:text-sm cursor-pointer hover:text-orange-600 transition"
                                 onClick={() => {
                                   window.open(suggestion.url, "_blank");
                                 }}
                               >
                                 {suggestion.title}
-                              </p>
+                              </button>
                             </div>
                             <Tooltip className="text-xs modal-tooltip" direction="top" content="Fill content">
                               <button
@@ -1024,13 +1024,13 @@ const HighlightInputForm = ({ refreshCallback }: HighlightInputFormProps): JSX.E
       )}
 
       <Fab className="md:hidden">
-        <div
+        <button
           onClick={() => setIsFormOpenMobile(true)}
-          className="p-3 mb-10 -mr-4 text-white rounded-full shadow-lg bg-light-orange-10"
+          className="outline-none p-3 mb-10 -mr-4 text-white rounded-full shadow-lg bg-light-orange-10"
           id="mobile-highlight-create"
         >
           <RxPencil1 className="text-3xl" />
-        </div>
+        </button>
       </Fab>
     </>
   );

--- a/components/molecules/HighlightInput/highlight-input-form.tsx
+++ b/components/molecules/HighlightInput/highlight-input-form.tsx
@@ -754,14 +754,13 @@ const HighlightInputForm = ({ refreshCallback }: HighlightInputFormProps): JSX.E
                                   }`}
                                 />
                               )}
-                              <button
-                                className="outline-none bg-none text-light-slate-11 truncate max-w-[14rem] xs:max-w-[16rem] text-xs xs:text-sm cursor-pointer hover:text-orange-600 transition"
-                                onClick={() => {
-                                  window.open(suggestion.url, "_blank");
-                                }}
+                              <a
+                                href={suggestion.url}
+                                target="_blank"
+                                className="truncate max-w-[14rem] xs:max-w-[16rem] text-xs xs:text-sm"
                               >
                                 {suggestion.title}
-                              </button>
+                              </a>
                             </div>
                             <Tooltip className="text-xs modal-tooltip" direction="top" content="Fill content">
                               <button
@@ -1023,14 +1022,14 @@ const HighlightInputForm = ({ refreshCallback }: HighlightInputFormProps): JSX.E
         </form>
       )}
 
-      <Fab className="md:hidden">
-        <button
-          onClick={() => setIsFormOpenMobile(true)}
+      <Fab className="md:hidden" onClick={() => setIsFormOpenMobile(true)}>
+        <span
           className="outline-none p-3 mb-10 -mr-4 text-white rounded-full shadow-lg bg-light-orange-10"
           id="mobile-highlight-create"
         >
+          <span className="sr-only">Create a highlight</span>
           <RxPencil1 className="text-3xl" />
-        </button>
+        </span>
       </Fab>
     </>
   );


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR fixes the Ally warning caused by jsx-ally, by using buttons to replace p and div elements that have `onClick`

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

Fixes #4137 

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [ ] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
