### PR TITLE
fix: fixed changing workspaces visibility regression

### DIFF
--- a/pages/workspaces/[workspaceId]/settings.tsx
+++ b/pages/workspaces/[workspaceId]/settings.tsx
@@ -276,7 +276,13 @@ const WorkspaceSettings = ({ workspace, canDeleteWorkspace }: WorkspaceSettingsP
           <div className="flex flex-col py-8 gap-4">
             <h2 className="!font-medium">Change Workspace Visibility</h2>
 
-            <Button variant="primary" className="w-fit">
+            <Button
+              variant="primary"
+              className="w-fit"
+              onClick={() => {
+                setIsWorkspaceVisibilityModalOpen(true);
+              }}
+            >
               Set to {isPublic ? "private" : "public"}
             </Button>
           </div>


### PR DESCRIPTION
## Description

Fixes a regression introduced in #4171

## Related Tickets & Documents

Relates to #4171

## Mobile & Desktop Screenshots/Recordings

![CleanShot 2024-10-17 at 16 30 27](https://github.com/user-attachments/assets/b51117a2-2977-4832-b6a0-6c756d969852)

## Steps to QA

1. Log in
2. Navigate to a workspace you own
3. Edit the workspace settings
4. Scroll to the visibility section
5. Click the `Set to private` button
6. Click the `yes, set to private` button in the modal
7. Do the same thing again, but to set it to private.


## Tier (staff will fill in)

- [ ] Tier 1
- [ ] Tier 2
- [ ] Tier 3
- [x] Tier 4

## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media4.giphy.com/media/JnMw4PjeX3jzy/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
