### PR TITLE
fix: Redirect to Linux Blog

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -132,4 +132,7 @@ export async function middleware(req: NextRequest) {
   if (!req.nextUrl.searchParams.has("redirectedFrom")) {
     return NextResponse.redirect(redirectUrl);
   }
+
+  // Redirect all routes to the Linux Blog
+  return NextResponse.redirect("https://opensauced.pizza/blog/opensauced-is-joining-the-linux-foundation");
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -46,7 +46,7 @@ status = 301
 force = true
 
 [[redirects]]
-from = "https://app.opensauced.pizza/*"
+from = "/*"
 to = "https://opensauced.pizza/blog/opensauced-is-joining-the-linux-foundation"
 status = 301
 force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -44,3 +44,9 @@ from = "https://hot.opensauced.pizza/*"
 to = "https://app.opensauced.pizza/explore"
 status = 301
 force = true
+
+[[redirects]]
+from = "https://app.opensauced.pizza/*"
+to = "https://opensauced.pizza/blog/opensauced-is-joining-the-linux-foundation"
+status = 301
+force = true


### PR DESCRIPTION
Fixes #4203

Redirect the app to the Linux Blog and take the product offline.

* **netlify.toml**: Add a redirect from `https://app.opensauced.pizza/*` to `https://opensauced.pizza/blog/opensauced-is-joining-the-linux-foundation`.
* **middleware.ts**: Add a check to redirect all routes to `https://opensauced.pizza/blog/opensauced-is-joining-the-linux-foundation`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/open-sauced/app/pull/4204?shareId=e8ba32d7-7e96-459a-85cb-1f0c6ddef147).